### PR TITLE
Fix CFY-1828:  cfy fails if .cloudify/config.yaml is missing

### DIFF
--- a/cloudify_cli/cli.py
+++ b/cloudify_cli/cli.py
@@ -19,6 +19,7 @@ import argparse
 import sys
 import traceback
 import argcomplete
+import utils
 import logging
 
 from cloudify_rest_client.exceptions import CloudifyClientError
@@ -31,7 +32,8 @@ verbose_output = False
 
 
 def main():
-    _configure_loggers()
+    if utils.is_initialized():
+        _configure_loggers()
     _set_cli_except_hook()
     args = _parse_args(sys.argv[1:])
     args.handler(args)

--- a/cloudify_cli/commands/init.py
+++ b/cloudify_cli/commands/init.py
@@ -33,10 +33,7 @@ def init(provider, reset_config):
     if provider is not None:
         return provider_common.provider_init(provider, reset_config)
 
-    if os.path.exists(os.path.join(
-            utils.get_cwd(),
-            constants.CLOUDIFY_WD_SETTINGS_DIRECTORY_NAME,
-            constants.CLOUDIFY_WD_SETTINGS_FILE_NAME)):
+    if utils.is_initialized():
         if not reset_config:
             msg = 'Current directory is already initialized'
             error = exceptions.CloudifyCliError(msg)

--- a/cloudify_cli/constants.py
+++ b/cloudify_cli/constants.py
@@ -15,6 +15,7 @@
 
 CLOUDIFY_WD_SETTINGS_FILE_NAME = 'context'
 CLOUDIFY_WD_SETTINGS_DIRECTORY_NAME = '.cloudify'
+CLOUDIFY_WD_CONFIG_FILE_NAME = 'config.yaml'
 CONFIG_FILE_NAME = 'cloudify-config.yaml'
 DEFAULTS_CONFIG_FILE_NAME = 'cloudify-config.defaults.yaml'
 

--- a/cloudify_cli/utils.py
+++ b/cloudify_cli/utils.py
@@ -34,6 +34,7 @@ from cloudify_rest_client import CloudifyClient
 from cloudify_cli.constants import DEFAULT_REST_PORT
 from cloudify_cli.constants import CLOUDIFY_WD_SETTINGS_FILE_NAME
 from cloudify_cli.constants import CLOUDIFY_WD_SETTINGS_DIRECTORY_NAME
+from cloudify_cli.constants import CLOUDIFY_WD_CONFIG_FILE_NAME
 from cloudify_cli.constants import CONFIG_FILE_NAME
 from cloudify_cli.constants import DEFAULTS_CONFIG_FILE_NAME
 from cloudify_cli.exceptions import CloudifyCliError
@@ -134,7 +135,8 @@ def json_to_dict(json_resource, json_resource_name):
 
 
 def is_initialized():
-    return get_init_path() is not None
+    config_path = get_configuration_path()
+    return config_path is not None and os.path.exists(config_path)
 
 
 def get_init_path():
@@ -154,17 +156,19 @@ def get_init_path():
 
 def get_configuration_path():
     dot_cloudify = get_init_path()
-    return os.path.join(
-        dot_cloudify,
-        'config.yaml'
-    )
+    if dot_cloudify is not None:
+        return os.path.join(
+            dot_cloudify,
+            CLOUDIFY_WD_CONFIG_FILE_NAME
+        )
+    return None
 
 
 def dump_configuration_file():
 
     config = pkg_resources.resource_string(
         cloudify_cli.__name__,
-        'resources/config.yaml')
+        'resources/%s' % CLOUDIFY_WD_CONFIG_FILE_NAME)
 
     template = Template(config)
     rendered = template.render(log_path=DEFAULT_LOG_FILE)


### PR DESCRIPTION
Fix is skipping the logger initialization if the .cloudify/config.yaml file is missing to aviod failing before executing command.