### PR TITLE
BUG missing dest_port for context service on use init

### DIFF
--- a/cloudify_cli/commands/use.py
+++ b/cloudify_cli/commands/use.py
@@ -45,7 +45,8 @@ def use(management_ip, provider, rest_port):
 
     try:
         response = utils.get_rest_client(
-            management_ip).manager.get_context()
+        manager_ip=management_ip,
+        rest_port=rest_port).manager.get_context()
         provider_name = response['name']
         provider_context = response['context']
     except CloudifyClientError:

--- a/cloudify_cli/commands/use.py
+++ b/cloudify_cli/commands/use.py
@@ -45,8 +45,8 @@ def use(management_ip, provider, rest_port):
 
     try:
         response = utils.get_rest_client(
-        manager_ip=management_ip,
-        rest_port=rest_port).manager.get_context()
+            manager_ip=management_ip,
+            rest_port=rest_port).manager.get_context()
         provider_name = response['name']
         provider_context = response['context']
     except CloudifyClientError:


### PR DESCRIPTION
Hi,
When i specfied tcp port for manager , i have error because port is wrong on context service request

    cfy use  -t 127.0.0.1 --port 8080  --debug

    Sending request: "GET http://127.0.0.1:80/provider/context"


I just add arg rest_port on the manager.getcontext call.


```
❯ cfy use  -t 127.0.0.1 --port 8080  --debug                                                                                                                                       ⏎
Sending request: "GET http://127.0.0.1:8080/status"
request header:  Connection: keep-alive
request header:  Content-type: application/json
request header:  Accept-Encoding: gzip, deflate
request header:  Accept: */*
request header:  User-Agent: python-requests/2.5.1 CPython/2.7.6 Darwin/14.0.0
reply:  "200 OK" {"status": "running", "services": [{"instances": [{"uptime": 75480, "pid": 506, "state": "up"}], "display_name": "Riemann"}, {"instances": [{"uptime": 75507, "pid": 112, "state": "up"}], "display_name": "Celery Managment"}, {"instances": [{"uptime": 75507, "pid": 110, "state": "up"}], "display_name": "Manager Rest-Service"}, {"instances": [{"uptime": 75507, "pid": 111, "state": "up"}], "display_name": "AMQP InfluxDB"}, {"instances": [{"uptime": 75507, "pid": 118, "state": "up"}], "display_name": "RabbitMQ"}, {"instances": [{"uptime": 75507, "pid": 113, "state": "up"}], "display_name": "Elasticsearch"}, {"instances": [{"uptime": 75507, "pid": 115, "state": "up"}], "display_name": "Webserver"}, {"instances": [{"uptime": 75507, "pid": 114, "state": "up"}], "display_name": "Cloudify UI"}, {"instances": [{"uptime": 75507, "pid": 109, "state": "up"}], "display_name": "Logstash"}]}
response header:  date: Fri, 09 Jan 2015 12:16:31 GMT
response header:  content-length: 887
response header:  content-type: application/json
response header:  connection: keep-alive
response header:  server: nginx/1.7.9
Sending request: "GET http://127.0.0.1:80/provider/context"
Traceback (most recent call last):
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/bin/cfy", line 9, in <module>
    load_entry_point('cloudify==3.1', 'console_scripts', 'cfy')()
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/cloudify_cli/cli.py", line 37, in main
    args.handler(args)
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/cloudify_cli/cli.py", line 143, in command_cmd_handler
    command['handler'](**kwargs)
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/cloudify_cli/commands/use.py", line 48, in use
    management_ip).manager.get_context()
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/cloudify_rest_client/manager.py", line 47, in get_context
    response = self.api.get('/provider/context', _include=_include)
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/cloudify_rest_client/client.py", line 130, in get
    expected_status_code=expected_status_code)
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/cloudify_rest_client/client.py", line 102, in do_request
    'Content-type': 'application/json'
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/requests/api.py", line 65, in get
    return request('get', url, **kwargs)
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/requests/api.py", line 49, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/requests/sessions.py", line 461, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/requests/sessions.py", line 573, in send
    r = adapter.send(request, **kwargs)
  File "/Users/gprudhomme/Documents/Missions/cloukr/cloukrcommonenv/lib/python2.7/site-packages/requests/adapters.py", line 415, in send
    raise ConnectionError(err, request=request)
ConnectionError: ('Connection aborted.', error(61, 'Connection refused'))
```
