### PR TITLE
CFY-1747 removed the --install-plugins flag from test.

### DIFF
--- a/cloudify_cli/tests/commands/test_local.py
+++ b/cloudify_cli/tests/commands/test_local.py
@@ -227,8 +227,7 @@ class LocalTest(CliCommandTest):
     def test_install_plugins_missing_windows_agent_installer(self):
         blueprint_path = '{0}/local/windows_installers_blueprint.yaml'\
             .format(BLUEPRINTS_DIR)
-        cli_runner.run_cli('cfy local init --install-plugins -p {0}'
-                           .format(blueprint_path))
+        cli_runner.run_cli('cfy local init -p {0}'.format(blueprint_path))
 
     @nose.tools.nottest
     def test_local_outputs(self):


### PR DESCRIPTION
There is no need to use --install-plugins flag to test the missing modules. 
The local init command fails if the modules are not ignored, as it should, even without using the flag.