### PR TITLE
CFY-2337: enable 'continue download functionality' in wget/curl

### DIFF
--- a/cloudify_cli/bootstrap/tasks.py
+++ b/cloudify_cli/bootstrap/tasks.py
@@ -667,11 +667,11 @@ def _run_docker_container(docker_exec_command, container_options,
 
 def _download_package(url, path, distro):
     if 'Ubuntu' in distro:
-        return _run_command('sudo wget {0} -P {1}'.format(
+        return _run_command('sudo wget {0} -P {1}  -c'.format(
             path, url))
     elif 'centos' in distro:
         with cd(path):
-            return _run_command('sudo curl -O {0}')
+            return _run_command('sudo curl -O {0} -C')
 
 
 def _unpack(path, distro):

--- a/cloudify_cli/provider_common.py
+++ b/cloudify_cli/provider_common.py
@@ -161,11 +161,11 @@ class BaseProviderClass(object):
 
         def _download_package(url, path, distro):
             if 'Ubuntu' in distro:
-                return _run_with_retries('sudo wget {0} -P {1}'.format(
+                return _run_with_retries('sudo wget {0} -P {1} -c'.format(
                     path, url))
             elif 'centos' in distro:
                 with cd(path):
-                    return _run_with_retries('sudo curl -O {0}')
+                    return _run_with_retries('sudo curl -O {0} -C')
 
         def _unpack(path, distro):
             if 'Ubuntu' in distro:


### PR DESCRIPTION
Use "continue download partial file feature" in wget/curl for minimize network traffic in case reattempt after failure operation.
