### PR TITLE
CFY-2796: cfy without command shows help message

### DIFF
--- a/cloudify_cli/cli.py
+++ b/cloudify_cli/cli.py
@@ -33,7 +33,8 @@ verbose_output = False
 def main():
     _configure_loggers()
     _set_cli_except_hook()
-    args = _parse_args(sys.argv[1:])
+    # Provide help message if there isn't command
+    args = _parse_args(sys.argv[1:] or ['-h'])
     args.handler(args)
 
 

--- a/cloudify_cli/tests/commands/test_without_command.py
+++ b/cloudify_cli/tests/commands/test_without_command.py
@@ -1,0 +1,26 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+"""
+Tests 'cfy'
+"""
+from cloudify_cli.tests import cli_runner
+from cloudify_cli.tests.commands.test_cli_command import CliCommandTest
+
+
+class CfyTest(CliCommandTest):
+
+    def test_cfy_without_command(self):
+        cli_runner.run_cli_expect_system_exit_0('cfy')


### PR DESCRIPTION
Added ability to provide help message if `cfy` uses without command.