### PR TITLE
Extended "cfy executions cancel" to include support for cancelling by deployment Id

### DIFF
--- a/cloudify_cli/cli.py
+++ b/cloudify_cli/cli.py
@@ -26,7 +26,6 @@ from cloudify_rest_client.exceptions import CloudifyClientError
 from cloudify_cli.exceptions import SuppressedCloudifyCliError
 from cloudify_cli.exceptions import CloudifyBootstrapError
 
-
 verbose_output = False
 
 

--- a/cloudify_cli/commands/executions.py
+++ b/cloudify_cli/commands/executions.py
@@ -243,12 +243,13 @@ def cancelByDeploymentId(deployment_id, force, wait, timeout=900):
 
         if wait:
             try:
-                logger.info('Waiting for execution {0} to finish being cancelled'
+                logger.info('Waiting for execution {0} to '
+                            'finish being cancelled'
                             .format(execution['id']))
                 execution = wait_for_cancel(client,
                                             execution,
                                             timeout=timeout)
-    
+
                 if execution.error:
                     logger.info("Cancellation of execution '{0}' "
                                 "failed. [error={2}]"
@@ -271,7 +272,7 @@ def cancelByExecutionId(execution_id, force, wait, timeout=900):
     logger.info(
         '{0}Cancelling execution {1} on management server {2}'
         .format('Force-' if force else '', execution_id, management_ip))
-    client.executions.cancel(execution_id, force)
+    execution = client.executions.cancel(execution_id, force)
     logger.info(
         'A cancel request for execution {0} has been sent to management '
         "server {1}. To track the execution's status, use:\n"

--- a/cloudify_cli/config/parser_config.py
+++ b/cloudify_cli/config/parser_config.py
@@ -349,6 +349,22 @@ def parser_config():
                                 'default': False,
                                 'help': 'A flag indicating authorization to terminate the execution abruptly '
                                         'rather than request an orderly termination'
+                            },
+                            '--wait': {
+                                'dest': 'wait',
+                                'action': 'store_true',
+                                'default': False,
+                                'help': 'A flag indicating to wait for the execution cancellation '
+                                        'to finish before continuing'
+                            },
+                            '--timeout': {
+                                'dest': 'timeout',
+                                'metavar': 'TIMEOUT',
+                                'type': int,
+                                'required': False,
+                                'default': 900,
+                                'help': 'Wait timeout in seconds (The execution itself will keep '
+                                        'going, it is the CLI that will stop waiting for it to terminate)'
                             }
                         },
                         'help': 'Cancel an execution by its execution ID or deployment ID',

--- a/cloudify_cli/config/parser_config.py
+++ b/cloudify_cli/config/parser_config.py
@@ -47,6 +47,11 @@ def deployment_id_argument(hlp):
         'completer': completion_utils.objects_args_completer_maker('deployments')
     }
 
+def deployment_id_argument_optional(hlp):
+    res = deployment_id_argument(hlp)
+    res['required'] = False
+    res['default'] = None
+    return res
 
 def execution_id_argument(hlp):
     return {
@@ -58,6 +63,11 @@ def execution_id_argument(hlp):
         'completer': completion_utils.objects_args_completer_maker('executions')
     }
 
+def execution_id_argument_optional(hlp):
+    res = execution_id_argument(hlp)
+    res['required'] = False
+    res['default'] = None
+    return res
 
 def workflow_id_argument(hlp):
     return {
@@ -327,8 +337,11 @@ def parser_config():
                     },
                     'cancel': {
                         'arguments': {
-                            '-e,--execution-id': execution_id_argument(
+                            '-e,--execution-id': execution_id_argument_optional(
                                 hlp='The id of the execution to cancel'
+                            ),
+                            '-d,--deployment-id': deployment_id_argument_optional(
+                                hlp='The id of the deployment to cancel executions for'
                             ),
                             '-f,--force': {
                                 'dest': 'force',
@@ -338,7 +351,7 @@ def parser_config():
                                         'rather than request an orderly termination'
                             }
                         },
-                        'help': 'Cancel an execution by its id',
+                        'help': 'Cancel an execution by its execution ID or deployment ID',
                         'handler': cfy.executions.cancel
                     }
                 }


### PR DESCRIPTION
It's annoying to have to track down an exact execution Id to cancel an execution. It's much easier to pass in a deployment Id (like the majority of other commands) and have any running execution cancelled for the deployment Id.  Now users can specify "-d" to the cancel operation as well as keeping the "-e" option. 
