### PR TITLE
CFY-5308 Use a local pip when installing plugins

### DIFF
--- a/cloudify_cli/common.py
+++ b/cloudify_cli/common.py
@@ -15,6 +15,7 @@
 ############
 
 import os
+import sys
 import tempfile
 
 from cloudify.utils import LocalCommandRunner
@@ -72,8 +73,9 @@ def install_blueprint_plugins(blueprint_path):
         # of cleanup in case an installation fails.
         tmp_path = tempfile.mkstemp(suffix='.txt', prefix='requirements_')[1]
         utils.dump_to_file(collection=requirements, file_path=tmp_path)
-        runner.run(command='pip install -r {0}'.format(tmp_path),
-                   stdout_pipe=False)
+        command_parts = [sys.executable, '-m', 'pip', 'install', '-r',
+                         tmp_path]
+        runner.run(command=' '.join(command_parts), stdout_pipe=False)
     else:
         get_logger().debug('There are no plugins to install..')
 


### PR DESCRIPTION
Don't use the pip that is on the PATH: it will be the system-global
pip if we're running `venv/bin/cfy` directly, without activating the
virtualenv.
Instead, use `sys.executable` to run `python -m pip` with the
virtualenv-local python.