### PR TITLE
Remove the incorrect comment

### DIFF
--- a/cloudify_cli/commands/__init__.py
+++ b/cloudify_cli/commands/__init__.py
@@ -37,7 +37,6 @@ from cloudify_cli.commands.ssh import ssh
 from cloudify_cli.commands.init import init
 from cloudify_cli.commands.recover import recover
 
-# import cfy sub commands
 from cloudify_cli.commands import plugins
 from cloudify_cli.commands import blueprints
 from cloudify_cli.commands import snapshots


### PR DESCRIPTION
It should remove the comment, which is " # import cfy sub commands ". I think that they are also direct commands for cfy.

@idanmo  PTAL.
Thanks!
