### PR TITLE
Replace func from shutil.rmtree(_workdir()) to delete_workdir()

### DIFF
--- a/cloudify_cli/bootstrap/bootstrap.py
+++ b/cloudify_cli/bootstrap/bootstrap.py
@@ -379,7 +379,7 @@ def teardown(name='manager',
                 task_thread_pool_size=task_thread_pool_size)
 
     # deleting local environment data
-    shutil.rmtree(_workdir())
+    delete_workdir()
 
 
 def recover(snapshot_path,


### PR DESCRIPTION
Replace func from shutil.rmtree(_workdir()) to delete_workdir() which it may be safe to delete a directory.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
