### PR TITLE
call configure loggers on startup

### DIFF
--- a/cloudify_cli/main.py
+++ b/cloudify_cli/main.py
@@ -15,6 +15,7 @@
 ############
 
 from . import env
+from . import logger
 from .cli import cfy
 from .commands import dev
 from .commands import ssh
@@ -130,7 +131,7 @@ def _register_commands():
         executions.executions.add_command(executions.local_start)
 
 _register_commands()
-
+logger.configure_loggers()
 
 if __name__ == '__main__':
     _cfy()


### PR DESCRIPTION
This fix is required so that loggers can be properly configured to DEBUG when running commands with `-vvv`. Otherwise, the loggers dict is not populated yet when the verbose configuration occurs