### PR TITLE
CFY-6003 Use optional argument instead of option

### DIFF
--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -170,15 +170,19 @@ def manager_update(deployment_id,
 
 @cfy.command(name='create',
              short_help='Create a deployment [manager only]')
+@cfy.argument('deployment-id', required=False)
 @cfy.options.blueprint_id(required=True)
-@cfy.options.deployment_id()
 @cfy.options.inputs
 @cfy.options.verbose()
 @cfy.assert_manager_active
 @cfy.pass_client()
 @cfy.pass_logger
 def manager_create(blueprint_id, deployment_id, inputs, logger, client):
-    """Create a deployment on the manager."""
+    """Create a deployment on the manager.
+
+    `DEPLOYMENT_ID` is the id of the deployment you'd like to create.
+
+    """
     logger.info('Creating new deployment from blueprint {0}...'.format(
         blueprint_id))
     deployment_id = deployment_id or blueprint_id

--- a/cloudify_cli/tests/commands/test_deployments.py
+++ b/cloudify_cli/tests/commands/test_deployments.py
@@ -166,7 +166,7 @@ class DeploymentsTest(CliCommandTest):
 
         self.client.deployments.create = MagicMock(return_value=deployment)
         self.invoke(
-            'cfy deployments create -b a-blueprint-id -d deployment')
+            'cfy deployments create deployment -b a-blueprint-id')
 
     def test_deployments_delete(self):
         self.client.deployments.delete = MagicMock()
@@ -323,7 +323,7 @@ class DeploymentsTest(CliCommandTest):
         self.client.deployments.create = raise_error
 
         outcome = self.invoke(
-            'cfy deployments create -b a-blueprint-id -d deployment',
+            'cfy deployments create deployment -b a-blueprint-id',
             err_str_segment='no inputs'
         )
         outcome = [o.strip() for o in outcome.logs.split('\n')]


### PR DESCRIPTION
In this PR the `cfy deployments create` command argument parsing is updated to use an argument for the `deployment_id` instead of an option.  