### PR TITLE
CFY-6006 Retry download without SSL verification on error

### DIFF
--- a/cloudify_cli/tests/test_utils.py
+++ b/cloudify_cli/tests/test_utils.py
@@ -18,10 +18,14 @@ from testtools import TestCase
 from testtools.matchers import Equals
 
 from mock import (
+    MagicMock as Mock,
     mock_open,
     patch,
 )
-from requests.exceptions import ConnectionError
+from requests.exceptions import (
+    ConnectionError,
+    SSLError,
+)
 
 from ..exceptions import CloudifyCliError
 from ..utils import download_file
@@ -64,6 +68,15 @@ class DownloadFileTest(TestCase):
     def test_download_success(self):
         """Download file successfully."""
         destination = download_file('some_url')
+        self.assertThat(destination, Equals(self.expected_destination))
+
+    def test_ssl_error(self):
+        """Download is retried without verification on SSL error."""
+        url = 'some_url'
+        response = Mock()
+        response.url = url
+        self.get.side_effect = [SSLError, response]
+        destination = download_file(url)
         self.assertThat(destination, Equals(self.expected_destination))
 
     def test_download_connection_error(self):

--- a/cloudify_cli/utils.py
+++ b/cloudify_cli/utils.py
@@ -179,7 +179,12 @@ def download_file(url, destination=None):
     logger.info('Downloading {0} to {1}...'.format(url, destination))
 
     try:
-        response = requests.get(url, stream=True)
+        try:
+            response = requests.get(url, stream=True)
+        except requests.exceptions.SSLError as ex:
+            logger.warning('SSL problem: %s', str(ex))
+            logger.info('Retrying without certificate verification...')
+            response = requests.get(url, stream=True, verify=False)
     except requests.exceptions.RequestException as ex:
         raise CloudifyCliError(
             'Failed to download {0}. ({1})'.format(url, str(ex)))


### PR DESCRIPTION
In this PR, when an attempt to download a file fails because of an SSL verification problem, a retry will be made with the verification step disabled. Note that this is just a workaround and a final fix will remove this behavior in the future. 