### PR TITLE
CFY-6006. Pass blueprint url to manager

### DIFF
--- a/cloudify_cli/blueprint.py
+++ b/cloudify_cli/blueprint.py
@@ -15,6 +15,7 @@
 ############
 
 import os
+from urlparse import urlparse
 
 from . import utils
 from .exceptions import CloudifyCliError
@@ -41,7 +42,7 @@ def get(source, blueprint_filename=DEFAULT_BLUEPRINT_PATH):
                 .format(blueprint_filename))
         return blueprint_file
 
-    if '://' in source:
+    if urlparse(source).scheme:
         downloaded_source = utils.download_file(source)
         return get_blueprint_file(downloaded_source)
     elif os.path.isfile(source):

--- a/cloudify_cli/blueprint.py
+++ b/cloudify_cli/blueprint.py
@@ -33,8 +33,11 @@ def get(source, blueprint_filename=DEFAULT_BLUEPRINT_PATH):
     """
     def get_blueprint_file(final_source):
         archive_root = utils.extract_archive(final_source)
-        blueprint = os.path.join(archive_root, os.listdir(archive_root)[0])
-        blueprint_file = os.path.join(blueprint, blueprint_filename)
+        blueprint_directory = os.path.join(
+            archive_root,
+            os.listdir(archive_root)[0],
+        )
+        blueprint_file = os.path.join(blueprint_directory, blueprint_filename)
         if not os.path.isfile(blueprint_file):
             raise CloudifyCliError(
                 'Could not find `{0}`. Please provide the name of the main '

--- a/cloudify_cli/blueprint.py
+++ b/cloudify_cli/blueprint.py
@@ -26,7 +26,7 @@ def get(source, blueprint_filename=DEFAULT_BLUEPRINT_PATH, download=False):
     """Get a source and return a directory containing the blueprint
 
     The behavior based on then source argument content is:
-        - local archive (.zip, .tar.gz):
+        - local archive:
             extract it locally and return path blueprint file
         - local yaml file: return the file
         - URL:
@@ -35,6 +35,8 @@ def get(source, blueprint_filename=DEFAULT_BLUEPRINT_PATH, download=False):
         - github repo:
             - map it to a URL and return it (download=False)
             - download and get blueprint from downloaded file (download=True)
+
+    Supported archive types are: zip, tar, tar.gz and tar.bz2
 
     :param source: Path/URL/github repo to archive/blueprint file
     :type source: str

--- a/cloudify_cli/blueprint.py
+++ b/cloudify_cli/blueprint.py
@@ -54,25 +54,24 @@ def get(source, blueprint_filename=DEFAULT_BLUEPRINT_PATH):
             # Maybe check if yaml. If not, verified by dsl parser
             return source
     elif len(source.split('/')) == 2:
-        downloaded_source = _get_from_github(source)
-        # GitHub archives provide an inner folder with each archive.
-        return get_blueprint_file(downloaded_source)
+        return _map_to_github_url(source)
     else:
         raise CloudifyCliError(
             'You must provide either a path to a local file, a remote URL '
             'or a GitHub `organization/repository[:tag/branch]`')
 
 
-def _get_from_github(source):
+def _map_to_github_url(source):
     """Returns a path to a downloaded github archive.
 
     Source to download should be in the format of `org/repo[:tag/branch]`.
+
     """
     source_parts = source.split(':', 1)
     repo = source_parts[0]
     tag = source_parts[1] if len(source_parts) == 2 else 'master'
     url = 'https://github.com/{0}/archive/{1}.tar.gz'.format(repo, tag)
-    return utils.download_file(url)
+    return url
 
 
 def generate_id(blueprint_path, blueprint_filename=DEFAULT_BLUEPRINT_PATH):

--- a/cloudify_cli/blueprint.py
+++ b/cloudify_cli/blueprint.py
@@ -43,8 +43,7 @@ def get(source, blueprint_filename=DEFAULT_BLUEPRINT_PATH):
         return blueprint_file
 
     if urlparse(source).scheme:
-        downloaded_source = utils.download_file(source)
-        return get_blueprint_file(downloaded_source)
+        return source
     elif os.path.isfile(source):
         if utils.is_archive(source):
             return get_blueprint_file(source)

--- a/cloudify_cli/blueprint.py
+++ b/cloudify_cli/blueprint.py
@@ -101,7 +101,10 @@ def _get_blueprint_file_from_archive(archive, blueprint_filename):
 def _map_to_github_url(source):
     """Returns a path to a downloaded github archive.
 
-    Source to download should be in the format of `org/repo[:tag/branch]`.
+    :param source: github repo in the format of `org/repo[:tag/branch]`.
+    :type source: str
+    :return: URL to the archive file for the given repo in github
+    :rtype: str
 
     """
     source_parts = source.split(':', 1)

--- a/cloudify_cli/blueprint.py
+++ b/cloudify_cli/blueprint.py
@@ -26,9 +26,10 @@ def get(source, blueprint_filename=DEFAULT_BLUEPRINT_PATH):
     """Get a source and return a directory containing the blueprint
 
     The behavior based on then source argument content is:
-        - URL: return it (let the manager download the blueprint later)
-        - local archive (.zip, .tar.gz): extract it and return blueprint file
+        - local archive (.zip, .tar.gz):
+            extract it locally and return path blueprint file
         - local yaml file: return the file
+        - URL: return it (let the manager download the blueprint later)
         - github repo: map it to a URL and return it
 
     :param source: Path/URL/github repo to archive/blueprint file

--- a/cloudify_cli/blueprint.py
+++ b/cloudify_cli/blueprint.py
@@ -31,6 +31,13 @@ def get(source, blueprint_filename=DEFAULT_BLUEPRINT_PATH):
         - local yaml file: return the file
         - github repo: map it to a URL and return it
 
+    :param source: Path/URL/github repo to archive/blueprint file
+    :type source: str
+    :param blueprint_filename: Path to blueprint (if source is an archive file)
+    :type blueprint_filename: str
+    :return: Path to file (if archive/blueprint file passsed) or url
+    :rtype: str
+
     """
     def get_blueprint_file(final_source):
         archive_root = utils.extract_archive(final_source)

--- a/cloudify_cli/blueprint.py
+++ b/cloudify_cli/blueprint.py
@@ -25,11 +25,12 @@ from .constants import DEFAULT_BLUEPRINT_PATH
 def get(source, blueprint_filename=DEFAULT_BLUEPRINT_PATH):
     """Get a source and return a directory containing the blueprint
 
-    if it's a URL of an archive, download and extract it.
-    if it's a local archive, extract it.
-    if it's a local yaml, return it.
-    else turn to github and try to get it.
-    else should implicitly fail.
+    The behavior based on then source argument content is:
+        - URL: return it (let the manager download the blueprint later)
+        - local archive (.zip, .tar.gz): extract it and return blueprint file
+        - local yaml file: return the file
+        - github repo: map it to a URL and return it
+
     """
     def get_blueprint_file(final_source):
         archive_root = utils.extract_archive(final_source)

--- a/cloudify_cli/commands/install.py
+++ b/cloudify_cli/commands/install.py
@@ -142,11 +142,14 @@ def local(ctx,
           task_thread_pool_size):
     """Install an application
 
-    `BLUEPRINT_PATH` can be either a local blueprint yaml file or
-    blueprint archive; a url to a blueprint archive or an
-    `organization/blueprint_repo[:tag/branch]` (to be
-    retrieved from GitHub).
+    `BLUEPRINT_PATH` can be a:
+        - local blueprint yaml file
+        - blueprint archive
+        - url to a blueprint archive
+        - github repo (`organization/blueprint_repo[:tag/branch]`)
+
     Supported archive types are: zip, tar, tar.gz and tar.bz2
+
     """
     processed_blueprint_path, blueprint_id = _get_blueprint_path_and_id(
         blueprint_path,

--- a/cloudify_cli/commands/install.py
+++ b/cloudify_cli/commands/install.py
@@ -190,7 +190,8 @@ def _get_blueprint_path_and_id(blueprint_path,
                                blueprint_id):
     processed_blueprint_path = blueprint.get(
         blueprint_path,
-        blueprint_filename
+        blueprint_filename,
+        download=True,
     )
 
     blueprint_id = blueprint_id or blueprint.generate_id(

--- a/cloudify_cli/tests/test_blueprint.py
+++ b/cloudify_cli/tests/test_blueprint.py
@@ -1,5 +1,6 @@
 import os
 
+from mock import patch
 from testtools import TestCase
 
 from .commands.constants import (
@@ -7,37 +8,58 @@ from .commands.constants import (
     SAMPLE_ARCHIVE_URL,
     SAMPLE_BLUEPRINT_PATH,
     SAMPLE_CUSTOM_NAME_ARCHIVE,
+    STUB_DIRECTORY_NAME,
 )
 from cloudify_cli import blueprint
 from cloudify_cli.exceptions import CloudifyCliError
 
 
-class TestGetBlueprint(TestCase):
+class TestGet(TestCase):
 
     """Test get a blueprint."""
 
     def test_yaml_path(self):
+        """Get a blueprint from a yaml file."""
         self.assertEqual(
             SAMPLE_BLUEPRINT_PATH,
             blueprint.get(SAMPLE_BLUEPRINT_PATH)
         )
 
-    def test_archive_default_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
-        self.assertIn(
-            'helloworld/blueprint.yaml',
-            blueprint.get(SAMPLE_ARCHIVE_PATH)
+    @patch('cloudify_cli.blueprint.os.path.isfile')
+    @patch('cloudify_cli.blueprint.os.listdir')
+    @patch('cloudify_cli.blueprint.utils.extract_archive')
+    def test_archive_default_name(self, extract_archive, listdir, isfile):
+        """Get a blueprint from a zip file."""
+        extract_archive.return_value = '/tmp'
+        listdir.return_value = ['directory']
+        isfile.return_value = True
+        self.assertEqual(
+            '/tmp/directory/blueprint.yaml',
+            blueprint.get(SAMPLE_ARCHIVE_PATH),
         )
 
-    def test_archive_custom_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
+    @patch('cloudify_cli.blueprint.os.path.isfile')
+    @patch('cloudify_cli.blueprint.os.listdir')
+    @patch('cloudify_cli.blueprint.utils.extract_archive')
+    def test_archive_custom_name(self, extract_archive, listdir, isfile):
+        """Get a blueprint with a custom name from a zip file."""
+        extract_archive.return_value = '/tmp'
+        listdir.return_value = ['directory']
+        isfile.return_value = True
         self.assertIn(
-            'helloworld/simple_blueprint.yaml',
+            'tmp/directory/simple_blueprint.yaml',
             blueprint.get(SAMPLE_CUSTOM_NAME_ARCHIVE, 'simple_blueprint.yaml')
         )
 
-    def test_archive_custom_name_no_default(self):
-        # There's no `blueprint.yaml` in the archive, so it should fail here
+    @patch('cloudify_cli.blueprint.os.path.isfile')
+    @patch('cloudify_cli.blueprint.os.listdir')
+    @patch('cloudify_cli.blueprint.utils.extract_archive')
+    def test_archive_custom_name_no_default(
+            self, extract_archive, listdir, isfile):
+        """Fail to get blueprint with a custom name from a zip file."""
+        extract_archive.return_value = '/tmp'
+        listdir.return_value = ['directory']
+        isfile.return_value = False
         self.assertRaises(
             CloudifyCliError,
             blueprint.get,
@@ -45,20 +67,21 @@ class TestGetBlueprint(TestCase):
         )
 
     def test_url_default_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
+        """Skip URL download."""
         self.assertEqual(
             blueprint.get(SAMPLE_ARCHIVE_URL),
             SAMPLE_ARCHIVE_URL,
         )
 
     def test_url_custom_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
+        """Ignore custom name in URL."""
         self.assertTrue(
             blueprint.get(SAMPLE_ARCHIVE_URL, 'ec2-blueprint.yaml'),
             SAMPLE_ARCHIVE_URL,
         )
 
     def test_bad_filename(self):
+        """Fail to get blueprint from a yaml file that doesn't exist."""
         self.assertRaises(
             CloudifyCliError,
             blueprint.get,
@@ -66,39 +89,50 @@ class TestGetBlueprint(TestCase):
         )
 
     def test_github_path(self):
+        """Map github repository path to URL."""
         # Can't check the whole path here, as it's a randomly generated temp
-        self.assertTrue(
-            blueprint.get(
-                'cloudify-cosmo/cloudify-hello-world-example'
-            ).endswith(
-                'cloudify-hello-world-example-master/blueprint.yaml',
-            )
+        self.assertEqual(
+            blueprint.get('cloudify-cosmo/cloudify-hello-world-example'),
+            (
+                'https://github.com/cloudify-cosmo/'
+                'cloudify-hello-world-example/archive/master.tar.gz'
+            ),
         )
 
     def test_github_path_custom_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
-        self.assertTrue(
+        """Map github repository path to URL and ignore custom name."""
+        self.assertEqual(
             blueprint.get(
                 'cloudify-cosmo/cloudify-hello-world-example',
                 'ec2-blueprint.yaml'
-            ).endswith(
-                'cloudify-hello-world-example-master/ec2-blueprint.yaml',
-            )
+            ),
+            (
+                'https://github.com/cloudify-cosmo/'
+                'cloudify-hello-world-example/archive/master.tar.gz'
+            ),
         )
 
+
+class TestGenerateId(TestCase):
+
+    """Test generate blueprint id."""
+
     def test_generate_id_default(self):
+        """Generate blueprint id from directory."""
         self.assertEqual(
-            'helloworld',
-            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH)
+            STUB_DIRECTORY_NAME,
+            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH),
         )
 
     def test_generate_id_custom(self):
+        """Generate blueprint id from directory and custom filename."""
         self.assertEqual(
-            'helloworld.test',
-            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH, 'test')
+            '{0}.test'.format(STUB_DIRECTORY_NAME),
+            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH, 'test.yaml')
         )
 
     def test_generate_id_in_blueprint_folder(self):
+        """Generate blueprint id from relative directory."""
         self.assertEqual(
             'helloworld',
             blueprint.generate_id(os.path.join('.', SAMPLE_BLUEPRINT_PATH)))

--- a/cloudify_cli/tests/test_blueprint.py
+++ b/cloudify_cli/tests/test_blueprint.py
@@ -1,15 +1,104 @@
+import os
+
 from testtools import TestCase
-from testtools.matchers import Equals
 
-from cloudify_cli.blueprint import get
+from .commands.constants import (
+    SAMPLE_ARCHIVE_PATH,
+    SAMPLE_ARCHIVE_URL,
+    SAMPLE_BLUEPRINT_PATH,
+    SAMPLE_CUSTOM_NAME_ARCHIVE,
+)
+from cloudify_cli import blueprint
+from cloudify_cli.exceptions import CloudifyCliError
 
 
-class TestGet(TestCase):
+class TestGetBlueprint(TestCase):
+
     """Test get a blueprint."""
 
-    def test_url(self):
-        """URLs are passed as they are to the manager."""
-        urls = ['http://example.com', 'https://example.com']
+    def test_yaml_path(self):
+        self.assertEqual(
+            SAMPLE_BLUEPRINT_PATH,
+            blueprint.get(SAMPLE_BLUEPRINT_PATH)
+        )
 
-        for url in urls:
-            self.assertThat(get(url), Equals(url))
+    def test_archive_default_name(self):
+        # Can't check the whole path here, as it's a randomly generated temp
+        self.assertIn(
+            'helloworld/blueprint.yaml',
+            blueprint.get(SAMPLE_ARCHIVE_PATH)
+        )
+
+    def test_archive_custom_name(self):
+        # Can't check the whole path here, as it's a randomly generated temp
+        self.assertIn(
+            'helloworld/simple_blueprint.yaml',
+            blueprint.get(SAMPLE_CUSTOM_NAME_ARCHIVE, 'simple_blueprint.yaml')
+        )
+
+    def test_archive_custom_name_no_default(self):
+        # There's no `blueprint.yaml` in the archive, so it should fail here
+        self.assertRaises(
+            CloudifyCliError,
+            blueprint.get,
+            SAMPLE_CUSTOM_NAME_ARCHIVE
+        )
+
+    def test_url_default_name(self):
+        # Can't check the whole path here, as it's a randomly generated temp
+        self.assertEqual(
+            blueprint.get(SAMPLE_ARCHIVE_URL),
+            SAMPLE_ARCHIVE_URL,
+        )
+
+    def test_url_custom_name(self):
+        # Can't check the whole path here, as it's a randomly generated temp
+        self.assertTrue(
+            blueprint.get(SAMPLE_ARCHIVE_URL, 'ec2-blueprint.yaml'),
+            SAMPLE_ARCHIVE_URL,
+        )
+
+    def test_bad_filename(self):
+        self.assertRaises(
+            CloudifyCliError,
+            blueprint.get,
+            'bad_filename.yaml'
+        )
+
+    def test_github_path(self):
+        # Can't check the whole path here, as it's a randomly generated temp
+        self.assertTrue(
+            blueprint.get(
+                'cloudify-cosmo/cloudify-hello-world-example'
+            ).endswith(
+                'cloudify-hello-world-example-master/blueprint.yaml',
+            )
+        )
+
+    def test_github_path_custom_name(self):
+        # Can't check the whole path here, as it's a randomly generated temp
+        self.assertTrue(
+            blueprint.get(
+                'cloudify-cosmo/cloudify-hello-world-example',
+                'ec2-blueprint.yaml'
+            ).endswith(
+                'cloudify-hello-world-example-master/ec2-blueprint.yaml',
+            )
+        )
+
+    def test_generate_id_default(self):
+        self.assertEqual(
+            'helloworld',
+            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH)
+        )
+
+    def test_generate_id_custom(self):
+        self.assertEqual(
+            'helloworld.test',
+            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH, 'test')
+        )
+
+    def test_generate_id_in_blueprint_folder(self):
+        self.assertEqual(
+            'helloworld',
+            blueprint.generate_id(os.path.join('.', SAMPLE_BLUEPRINT_PATH)))

--- a/cloudify_cli/tests/test_blueprint.py
+++ b/cloudify_cli/tests/test_blueprint.py
@@ -1,0 +1,15 @@
+from testtools import TestCase
+from testtools.matchers import Equals
+
+from cloudify_cli.blueprint import get
+
+
+class TestGet(TestCase):
+    """Test get a blueprint."""
+
+    def test_url(self):
+        """URLs are passed as they are to the manager."""
+        urls = ['http://example.com', 'https://example.com']
+
+        for url in urls:
+            self.assertThat(get(url), Equals(url))

--- a/cloudify_cli/tests/test_blueprint.py
+++ b/cloudify_cli/tests/test_blueprint.py
@@ -2,6 +2,7 @@ import os
 
 from mock import patch
 from testtools import TestCase
+from testtools.matchers import Equals
 
 from .commands.constants import (
     SAMPLE_ARCHIVE_PATH,
@@ -20,9 +21,9 @@ class TestGet(TestCase):
 
     def test_yaml_path(self):
         """Get a blueprint from a yaml file."""
-        self.assertEqual(
-            SAMPLE_BLUEPRINT_PATH,
-            blueprint.get(SAMPLE_BLUEPRINT_PATH)
+        self.assertThat(
+            blueprint.get(SAMPLE_BLUEPRINT_PATH),
+            Equals(SAMPLE_BLUEPRINT_PATH),
         )
 
     @patch('cloudify_cli.blueprint.os.path.isfile')
@@ -33,9 +34,9 @@ class TestGet(TestCase):
         extract_archive.return_value = '/tmp'
         listdir.return_value = ['directory']
         isfile.return_value = True
-        self.assertEqual(
-            '/tmp/directory/blueprint.yaml',
+        self.assertThat(
             blueprint.get(SAMPLE_ARCHIVE_PATH),
+            Equals('/tmp/directory/blueprint.yaml'),
         )
 
     @patch('cloudify_cli.blueprint.os.path.isfile')
@@ -46,9 +47,9 @@ class TestGet(TestCase):
         extract_archive.return_value = '/tmp'
         listdir.return_value = ['directory']
         isfile.return_value = True
-        self.assertIn(
-            'tmp/directory/simple_blueprint.yaml',
-            blueprint.get(SAMPLE_CUSTOM_NAME_ARCHIVE, 'simple_blueprint.yaml')
+        self.assertThat(
+            blueprint.get(SAMPLE_CUSTOM_NAME_ARCHIVE, 'simple_blueprint.yaml'),
+            Equals('/tmp/directory/simple_blueprint.yaml'),
         )
 
     @patch('cloudify_cli.blueprint.os.path.isfile')
@@ -68,16 +69,16 @@ class TestGet(TestCase):
 
     def test_url_default_name(self):
         """Skip URL download."""
-        self.assertEqual(
+        self.assertThat(
             blueprint.get(SAMPLE_ARCHIVE_URL),
-            SAMPLE_ARCHIVE_URL,
+            Equals(SAMPLE_ARCHIVE_URL),
         )
 
     def test_url_custom_name(self):
         """Ignore custom name in URL."""
-        self.assertTrue(
+        self.assertThat(
             blueprint.get(SAMPLE_ARCHIVE_URL, 'ec2-blueprint.yaml'),
-            SAMPLE_ARCHIVE_URL,
+            Equals(SAMPLE_ARCHIVE_URL),
         )
 
     def test_bad_filename(self):
@@ -91,9 +92,9 @@ class TestGet(TestCase):
     def test_github_path(self):
         """Map github repository path to URL."""
         # Can't check the whole path here, as it's a randomly generated temp
-        self.assertEqual(
+        self.assertThat(
             blueprint.get('cloudify-cosmo/cloudify-hello-world-example'),
-            (
+            Equals(
                 'https://github.com/cloudify-cosmo/'
                 'cloudify-hello-world-example/archive/master.tar.gz'
             ),
@@ -101,12 +102,12 @@ class TestGet(TestCase):
 
     def test_github_path_custom_name(self):
         """Map github repository path to URL and ignore custom name."""
-        self.assertEqual(
+        self.assertThat(
             blueprint.get(
                 'cloudify-cosmo/cloudify-hello-world-example',
                 'ec2-blueprint.yaml'
             ),
-            (
+            Equals(
                 'https://github.com/cloudify-cosmo/'
                 'cloudify-hello-world-example/archive/master.tar.gz'
             ),
@@ -119,20 +120,21 @@ class TestGenerateId(TestCase):
 
     def test_generate_id_default(self):
         """Generate blueprint id from directory."""
-        self.assertEqual(
-            STUB_DIRECTORY_NAME,
+        self.assertThat(
             blueprint.generate_id(SAMPLE_BLUEPRINT_PATH),
+            Equals(STUB_DIRECTORY_NAME),
         )
 
     def test_generate_id_custom(self):
         """Generate blueprint id from directory and custom filename."""
-        self.assertEqual(
-            '{0}.test'.format(STUB_DIRECTORY_NAME),
-            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH, 'test.yaml')
+        self.assertThat(
+            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH, 'test.yaml'),
+            Equals('{0}.test'.format(STUB_DIRECTORY_NAME)),
         )
 
     def test_generate_id_in_blueprint_folder(self):
         """Generate blueprint id from relative directory."""
-        self.assertEqual(
-            'helloworld',
-            blueprint.generate_id(os.path.join('.', SAMPLE_BLUEPRINT_PATH)))
+        self.assertThat(
+            blueprint.generate_id(os.path.join('.', SAMPLE_BLUEPRINT_PATH)),
+            Equals('helloworld'),
+        )

--- a/cloudify_cli/tests/test_env.py
+++ b/cloudify_cli/tests/test_env.py
@@ -50,7 +50,6 @@ from .. import utils
 from .. import inputs
 from .. import logger
 from .. import constants
-from .. import blueprint
 from ..config import config
 from .. import local as cli_local
 from ..bootstrap import bootstrap
@@ -65,8 +64,7 @@ from . import cfy
 
 from .commands.test_base import CliCommandTest
 from .commands.mocks import mock_logger, mock_stdout, MockListResponse
-from .commands.constants import BLUEPRINTS_DIR, SAMPLE_BLUEPRINT_PATH, \
-    SAMPLE_ARCHIVE_PATH, SAMPLE_CUSTOM_NAME_ARCHIVE, SAMPLE_ARCHIVE_URL
+from .commands.constants import BLUEPRINTS_DIR, SAMPLE_BLUEPRINT_PATH
 
 
 class TestCLIBase(CliCommandTest):
@@ -1058,97 +1056,6 @@ class TestGetRestClient(CliCommandTest):
         self.assertEqual('{0}://{1}:{2}/api/{3}'.format(
             rest_protocol, host, port, DEFAULT_API_VERSION),
             client._client.url)
-
-
-class TestGetBlueprint(CliCommandTest):
-    def test_yaml_path(self):
-        self.assertEqual(
-            SAMPLE_BLUEPRINT_PATH,
-            blueprint.get(SAMPLE_BLUEPRINT_PATH)
-        )
-
-    def test_archive_default_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
-        self.assertIn(
-            'helloworld/blueprint.yaml',
-            blueprint.get(SAMPLE_ARCHIVE_PATH)
-        )
-
-    def test_archive_custom_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
-        self.assertIn(
-            'helloworld/simple_blueprint.yaml',
-            blueprint.get(SAMPLE_CUSTOM_NAME_ARCHIVE, 'simple_blueprint.yaml')
-        )
-
-    def test_archive_custom_name_no_default(self):
-        # There's no `blueprint.yaml` in the archive, so it should fail here
-        self.assertRaises(
-            CloudifyCliError,
-            blueprint.get,
-            SAMPLE_CUSTOM_NAME_ARCHIVE
-        )
-
-    def test_url_default_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
-        self.assertTrue(
-            blueprint.get(SAMPLE_ARCHIVE_URL).endswith(
-                'cloudify-hello-world-example-master/blueprint.yaml',
-            )
-        )
-
-    def test_url_custom_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
-        self.assertTrue(
-            blueprint.get(SAMPLE_ARCHIVE_URL, 'ec2-blueprint.yaml').endswith(
-                'cloudify-hello-world-example-master/ec2-blueprint.yaml',
-            )
-        )
-
-    def test_bad_filename(self):
-        self.assertRaises(
-            CloudifyCliError,
-            blueprint.get,
-            'bad_filename.yaml'
-        )
-
-    def test_github_path(self):
-        # Can't check the whole path here, as it's a randomly generated temp
-        self.assertTrue(
-            blueprint.get(
-                'cloudify-cosmo/cloudify-hello-world-example'
-            ).endswith(
-                'cloudify-hello-world-example-master/blueprint.yaml',
-            )
-        )
-
-    def test_github_path_custom_name(self):
-        # Can't check the whole path here, as it's a randomly generated temp
-        self.assertTrue(
-            blueprint.get(
-                'cloudify-cosmo/cloudify-hello-world-example',
-                'ec2-blueprint.yaml'
-            ).endswith(
-                'cloudify-hello-world-example-master/ec2-blueprint.yaml',
-            )
-        )
-
-    def test_generate_id_default(self):
-        self.assertEqual(
-            'helloworld',
-            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH)
-        )
-
-    def test_generate_id_custom(self):
-        self.assertEqual(
-            'helloworld.test',
-            blueprint.generate_id(SAMPLE_BLUEPRINT_PATH, 'test')
-        )
-
-    def test_generate_id_in_blueprint_folder(self):
-        self.assertEqual(
-            'helloworld',
-            blueprint.generate_id(os.path.join('.', SAMPLE_BLUEPRINT_PATH)))
 
 
 class TestUtils(CliCommandTest):


### PR DESCRIPTION
In this PR, the code that downloads the blueprint file when a URL or a github repo is passed as argument is only used when installed the blueprint locally. When the blueprint is to be uploaded to the manager, the URL is passed directly and the manager is expected to download the blueprint file itself.

What concerns me is that there's a `blueprint_filename` parameter that is used to specify when the blueprint file in an archive file is not the default one and that information is lost when the URL is passed to the manager. Any comment/suggestion about this?