### PR TITLE
CFY-6006 Use publish_archive instead of upload when a url is passed

### DIFF
--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -134,9 +134,9 @@ def upload(ctx,
                 progress_handler,
             )
         finally:
-            # Every situation other than the user providing a path of a local
-            # yaml means a temp folder will be created that should be later
-            # removed.
+            # When an archive file is passed, it's extracted to a temporary
+            # directory to get the blueprint file. Once the blueprint has been
+            # uploaded, the temporary directory needs to be cleaned up.
             if processed_blueprint_path != blueprint_path:
                 temp_directory = os.path.dirname(
                     os.path.dirname(processed_blueprint_path)

--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -106,19 +106,19 @@ def upload(ctx,
     blueprint_id = blueprint_id or blueprint.generate_id(
         processed_blueprint_path, blueprint_filename)
 
-    try:
-        if is_url:
-            # When a URL is passed it's assumed to be pointing to an archive
-            # file that contains the blueprint. Hence, the `publish_archive`
-            # API call is the one that should be used.
-            logger.info('Publishing blueprint archive %s...', blueprint_path)
-            client.blueprints.publish_archive(
-                blueprint_path,
-                blueprint_id,
-                blueprint_filename,
-                progress_handler,
-            )
-        else:
+    if is_url:
+        # When a URL is passed it's assumed to be pointing to an archive
+        # file that contains the blueprint. Hence, the `publish_archive`
+        # API call is the one that should be used.
+        logger.info('Publishing blueprint archive %s...', blueprint_path)
+        client.blueprints.publish_archive(
+            blueprint_path,
+            blueprint_id,
+            blueprint_filename,
+            progress_handler,
+        )
+    else:
+        try:
             if validate:
                 ctx.invoke(
                     validate_blueprint,
@@ -133,15 +133,18 @@ def upload(ctx,
                 blueprint_id,
                 progress_handler,
             )
-        logger.info("Blueprint uploaded. The blueprint's id is {0}".format(
-            blueprint_obj.id))
-    finally:
-        # Every situation other than the user providing a path of a local
-        # yaml means a temp folder will be created that should be later
-        # removed.
-        if processed_blueprint_path != blueprint_path:
-            shutil.rmtree(os.path.dirname(os.path.dirname(
-                processed_blueprint_path)))
+        finally:
+            # Every situation other than the user providing a path of a local
+            # yaml means a temp folder will be created that should be later
+            # removed.
+            if processed_blueprint_path != blueprint_path:
+                temp_directory = os.path.dirname(
+                    os.path.dirname(processed_blueprint_path)
+                )
+                shutil.rmtree(temp_directory)
+
+    logger.info("Blueprint uploaded. The blueprint's id is {0}".format(
+        blueprint_obj.id))
 
 
 @blueprints.command(name='download',

--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -98,6 +98,8 @@ def upload(ctx,
     processed_blueprint_path = blueprint.get(
         blueprint_path, blueprint_filename)
 
+    # Take into account that `blueprint.get` might not return a URL
+    # instead of a blueprint file (archive files are not locally downloaded)
     is_url = bool(urlparse(processed_blueprint_path).scheme)
 
     progress_handler = utils.generate_progress_handler(blueprint_path, '')
@@ -106,6 +108,9 @@ def upload(ctx,
 
     try:
         if is_url:
+            # When a URL is passed it's assumed to be pointing to an archive
+            # file that contains the blueprint. Hence, the `publish_archive`
+            # API call is the one that should be used.
             logger.info('Publishing blueprint archive %s...', blueprint_path)
             client.blueprints.publish_archive(
                 blueprint_path,
@@ -120,6 +125,8 @@ def upload(ctx,
                     blueprint_path=processed_blueprint_path,
                 )
 
+            # When the blueprint file is already available locally, it can be
+            # uploaded directly using the `upload` API call.
             logger.info('Uploading blueprint %s...', blueprint_path)
             blueprint_obj = client.blueprints.upload(
                 processed_blueprint_path,


### PR DESCRIPTION
When a URL is passed, the `client.blueprints.upload` call is no longer
useful because it expects a file to be passed. The right API call in
this case is `client.blueprints.publish_archive`.