### PR TITLE
CFY-6005. Fix use callback invocation

### DIFF
--- a/cloudify_cli/commands/teardown.py
+++ b/cloudify_cli/commands/teardown.py
@@ -19,7 +19,6 @@ from cloudify_rest_client.exceptions import CloudifyClientError
 from .. import env
 from .use import use
 from .. import exceptions
-from ..env import profile
 from ..cli import cfy, helptexts
 from ..bootstrap import bootstrap as bs
 
@@ -44,7 +43,7 @@ def teardown(ctx,
     _assert_force(force)
 
     try:
-        manager_ip = profile.manager_ip
+        manager_ip = env.profile.manager_ip
     except exceptions.CloudifyCliError:
         # manager ip does not exist in the local context
         # this can mean one of two things:
@@ -95,7 +94,7 @@ def _update_local_provider_context(ctx, manager_ip, logger):
         ctx.invoke(
             use,
             profile_name=manager_ip,
-            rest_port=profile.rest_port,
+            rest_port=env.profile.rest_port,
         )
     except BaseException as e:
         logger.warning('Failed to retrieve provider context: {0}. This '

--- a/cloudify_cli/commands/teardown.py
+++ b/cloudify_cli/commands/teardown.py
@@ -31,8 +31,10 @@ from ..bootstrap import bootstrap as bs
 @cfy.options.task_retry_interval()
 @cfy.options.task_thread_pool_size()
 @cfy.options.verbose()
+@cfy.pass_context
 @cfy.assert_manager_active()
-def teardown(force,
+def teardown(ctx,
+             force,
              ignore_deployments,
              task_retries,
              task_retry_interval,
@@ -78,7 +80,7 @@ def teardown(force,
 
         # update local provider context since the server ip might have
         # changed in case it has gone through a recovery process.
-        _update_local_provider_context(manager_ip)
+        _update_local_provider_context(ctx, manager_ip)
 
         # execute teardown
         _do_teardown(
@@ -88,13 +90,11 @@ def teardown(force,
 
 
 @cfy.pass_logger
-def _update_local_provider_context(manager_ip, logger):
+def _update_local_provider_context(ctx, manager_ip, logger):
     try:
-        use.callback(
+        ctx.invoke(
+            use,
             profile_name=manager_ip,
-            manager_user=None,
-            manager_key=None,
-            manager_port=None,
             rest_port=profile.rest_port,
         )
     except BaseException as e:

--- a/cloudify_cli/commands/teardown.py
+++ b/cloudify_cli/commands/teardown.py
@@ -90,7 +90,13 @@ def teardown(force,
 @cfy.pass_logger
 def _update_local_provider_context(manager_ip, logger):
     try:
-        use(manager_ip, profile.rest_port)
+        use.callback(
+            profile_name=manager_ip,
+            manager_user=None,
+            manager_key=None,
+            manager_port=None,
+            rest_port=profile.rest_port,
+        )
     except BaseException as e:
         logger.warning('Failed to retrieve provider context: {0}. This '
                        'may cause a leaking manager '

--- a/cloudify_cli/tests/commands/test_teardown.py
+++ b/cloudify_cli/tests/commands/test_teardown.py
@@ -1,5 +1,3 @@
-import sys
-
 from mock import patch, MagicMock
 
 from .. import env
@@ -24,7 +22,6 @@ class TeardownTest(CliCommandTest):
         )
         self.invoke('cfy use 10.0.0.1 -m admin -p admin')
         env.profile = env.get_profile_context(suppress_error=True)
-        sys.modules['cloudify_cli.commands.teardown'].profile = env.profile
         self.invoke('cfy teardown -f --ignore-deployments')
         mock_teardown.assert_called_once_with(
             task_retries=0,

--- a/cloudify_cli/tests/commands/test_teardown.py
+++ b/cloudify_cli/tests/commands/test_teardown.py
@@ -1,3 +1,5 @@
+import sys
+
 from mock import patch, MagicMock
 
 from .. import env
@@ -22,6 +24,7 @@ class TeardownTest(CliCommandTest):
         )
         self.invoke('cfy use 10.0.0.1 -m admin -p admin')
         env.profile = env.get_profile_context(suppress_error=True)
+        sys.modules['cloudify_cli.commands.teardown'].profile = env.profile
         self.invoke('cfy teardown -f --ignore-deployments')
         mock_teardown.assert_called_once_with(
             task_retries=0,


### PR DESCRIPTION
In this PR, the `use` command that was called directly from the `teardown` one is now called using `ctxt.invoke` to avoid parsing arguments from the command line.

Note: I had to include 2832295 in this branch make the test cases pass. However, the commit is not in the `master` branch. I believe the commit should be pushed to the `master` branch before this branch, so that the diff in this branch contains only the changes related to the issue that has been fixed.