### PR TITLE
CFY-6009 Add the 'cfy ha start' command for starting a HA cluster

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -14,11 +14,13 @@
 # limitations under the License.
 ############
 
+import os
 import sys
 import difflib
 import StringIO
 import traceback
 from functools import wraps
+from base64 import standard_b64encode
 
 import click
 
@@ -35,6 +37,7 @@ from ..constants import DEFAULT_BLUEPRINT_PATH
 from ..exceptions import CloudifyBootstrapError
 from ..exceptions import SuppressedCloudifyCliError
 from ..logger import get_logger, set_global_verbosity_level, DEFAULT_LOG_FILE
+from ..utils import generate_random_string
 
 
 CLICK_CONTEXT_SETTINGS = dict(
@@ -620,6 +623,17 @@ class Options(object):
             required=True,
             help=helptexts.PASSWORD)
 
+        self.cluster_host_ip = click.option(
+            '--cluster-host-ip',
+            required=True,
+            help=helptexts.CLUSTER_HOST_IP)
+
+        self.cluster_node_name = click.option(
+            '--cluster-node-name',
+            default=lambda: 'cloudify_manager_' + generate_random_string(),
+            help=helptexts.CLUSTER_NODE_NAME
+        )
+
     @staticmethod
     def include_keys(help):
         return click.option(
@@ -744,6 +758,19 @@ class Options(object):
             '--blueprint-path',
             required=required,
             type=click.Path(exists=True))
+
+    @staticmethod
+    def cluster_encryption_key(with_default=False):
+        if with_default:
+            def default():
+                return standard_b64encode(os.urandom(16))
+        else:
+            default = None
+
+        return click.option(
+            '--cluster-encryption-key',
+            default=default,
+            help=helptexts.CLUSTER_ENCRYPTION_KEY)
 
 
 options = Options()

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -176,3 +176,13 @@ GROUP = 'The name of the user group'
 SECURITY_ROLE = "A role to determine the user's permissions on the manager " \
                 "[administrator|default|viewer|suspended] (default: default)"
 PASSWORD = 'Cloudify manager password'
+
+CLUSTER_ENCRYPTION_KEY = (
+    'The encryption key for the cluster (needs to be the same for all '
+    'members). A new key will be generated if not set.'
+)
+
+CLUSTER_HOST_IP = \
+    'The IP of this machine to use for advertising to the cluster'
+CLUSTER_NODE_NAME = \
+    'Name of this manager machine to be used internally in the cluster'

--- a/cloudify_cli/commands/cluster.py
+++ b/cloudify_cli/commands/cluster.py
@@ -1,0 +1,50 @@
+########
+# Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+############
+
+from .. import env
+from ..cli import cfy
+from ..exceptions import CloudifyCliError
+
+
+def _verify_not_in_cluster(client):
+    status = client.cluster.status()
+    if status.initialized:
+        raise CloudifyCliError('This manager machine is already part '
+                               'of a HA cluster')
+
+
+@cfy.group(name='ha')
+@cfy.options.verbose()
+def cluster():
+    """Handle the Manager HA Cluster
+    """
+    if not env.is_initialized():
+        env.raise_uninitialized()
+
+
+@cluster.command(name='status',
+                 short_help='Show the current cluster status [cluster only]')
+@cfy.pass_client()
+@cfy.pass_logger
+def status(client, logger):
+    """Display the current status of the HA cluster
+    """
+    status = client.cluster.status()
+    if not status.initialized:
+        logger.error('This manager is not part of a Cloudify HA cluster')
+    else:
+        logger.info('HA cluster initialized!\nEncryption key: {0}'
+                    .format(status.encryption_key))

--- a/cloudify_cli/commands/cluster.py
+++ b/cloudify_cli/commands/cluster.py
@@ -14,12 +14,18 @@
 # limitations under the License.
 ############
 
+import time
+from datetime import datetime
+
 from .. import env
 from ..cli import cfy
 from ..exceptions import CloudifyCliError
+from ..execution_events_fetcher import WAIT_FOR_EXECUTION_SLEEP_INTERVAL
 
 
 def _verify_not_in_cluster(client):
+    """Check that the current manager doesn't already belong to a cluster
+    """
     status = client.cluster.status()
     if status.initialized:
         raise CloudifyCliError('This manager machine is already part '
@@ -48,3 +54,82 @@ def status(client, logger):
     else:
         logger.info('HA cluster initialized!\nEncryption key: {0}'
                     .format(status.encryption_key))
+
+
+@cluster.command(name='start',
+                 short_help='Start a HA manager cluster [manager only]')
+@cfy.pass_client()
+@cfy.pass_logger
+@cfy.options.timeout()
+@cfy.options.cluster_host_ip
+@cfy.options.cluster_node_name
+@cfy.options.cluster_encryption_key(with_default=True)
+def start(client,
+          logger,
+          timeout,
+          cluster_host_ip,
+          cluster_node_name,
+          cluster_encryption_key):
+    """Start a HA manager cluster with the current manager as the master.
+
+    This will initialize all the HA cluster components on the current manager,
+    and mark it as the master. After that, other managers will be able to
+    join the cluster by passing this manager's IP address and encryption key.
+    """
+
+    _verify_not_in_cluster(client)
+
+    logger.info('Creating a new Cloudify HA cluster')
+
+    client.cluster.start(config={
+        'host_ip': cluster_host_ip,
+        'node_name': cluster_node_name,
+        'encryption_key': cluster_encryption_key
+    })
+    status = _wait_for_cluster_initialized(client, logger)
+
+    if status.error:
+        logger.error('Error while configuring the HA cluster')
+        raise CloudifyCliError(status.error)
+
+    logger.info('HA cluster started at {0}.\n'
+                'Encryption key used is: {1}'
+                .format(cluster_host_ip, cluster_encryption_key))
+
+
+def _wait_for_cluster_initialized(client, logger=None, timeout=900):
+    # this is similar to how an execution's logs and status are fetched,
+    # but is using a different backend mechanism
+    include = None
+    if logger is not None:
+        # only fetch logs when the logger is present - no need otherwise
+        include = ['logs', 'initialized', 'error']
+
+    # each log message will have a "cursor" value - we need to tell the server
+    # what's the latest cursor position we've already seen, so that it'll only
+    # yield logs more recent than that.
+    last_log = None
+
+    while True:
+        if timeout is not None:
+            timeout -= WAIT_FOR_EXECUTION_SLEEP_INTERVAL
+            if timeout < 0:
+                raise CloudifyCliError('Timed out waiting for the HA '
+                                       'cluster to be initialized.')
+
+        status = client.cluster.status(
+            _include=include,
+            since=last_log)
+        if status.logs:
+            last_log = status.logs[-1]['cursor']
+
+        for log in status.logs:
+            timestamp = datetime.utcfromtimestamp(log['timestamp'] // 1e6)
+            logger.info('{0} {1}'.format(timestamp.isoformat(),
+                                         log['message']))
+
+        if status.initialized or status.error:
+            break
+        time.sleep(WAIT_FOR_EXECUTION_SLEEP_INTERVAL)
+
+    return status

--- a/cloudify_cli/main.py
+++ b/cloudify_cli/main.py
@@ -28,6 +28,7 @@ from .commands import agents
 from .commands import events
 from .commands import groups
 from .commands import status
+from .commands import cluster
 from .commands import install
 from .commands import plugins
 from .commands import recover
@@ -88,6 +89,7 @@ def _register_commands():
     _cfy.add_command(users.users)
     _cfy.add_command(agents.agents)
     _cfy.add_command(events.events)
+    _cfy.add_command(cluster.cluster)
     _cfy.add_command(plugins.plugins)
     _cfy.add_command(upgrade.upgrade)
     _cfy.add_command(tenants.tenants)

--- a/cloudify_cli/tests/commands/test_cluster.py
+++ b/cloudify_cli/tests/commands/test_cluster.py
@@ -1,0 +1,137 @@
+########
+# Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+############
+
+import mock
+import unittest
+
+from cloudify_rest_client.cluster import ClusterState
+
+from .test_base import CliCommandTest
+from ...exceptions import CloudifyCliError
+from ...commands.cluster import _wait_for_cluster_initialized
+from ...execution_events_fetcher import WAIT_FOR_EXECUTION_SLEEP_INTERVAL
+
+
+class WaitForClusterTest(unittest.TestCase):
+    def test_polls_until_done(self):
+        """The CLI stops polling when the cluster is initialized."""
+
+        client = mock.Mock()
+        # prepare a mock "cluster.status()" method that will return
+        # initialized = False on the first 4 calls, and initialized = True
+        # on the 5th call
+        client.cluster.status = mock.Mock(
+            side_effect=[ClusterState({'initialized': False})] * 4 +
+                        [ClusterState({'initialized': True})])
+
+        with mock.patch('cloudify_cli.commands.cluster.time'):
+            status = _wait_for_cluster_initialized(client)
+        self.assertEqual(5, len(client.cluster.status.mock_calls))
+        self.assertTrue(status['initialized'])
+
+    def test_stops_at_timeout(self):
+        """If the cluster is never started, polling stops at timeout."""
+        timeout = 900
+        client = mock.Mock()
+        client.cluster.status = mock.Mock(
+            return_value=ClusterState({'initialized': False}))
+
+        with mock.patch('cloudify_cli.commands.cluster.time') as mock_time:
+            with self.assertRaises(CloudifyCliError) as cm:
+                _wait_for_cluster_initialized(client, timeout=timeout)
+
+        self.assertIn('timed out', cm.exception.message.lower())
+        # there should be (timeout//interval) time.sleep(interval) calls,
+        # so the total time waited is equal to timeout
+        self.assertEqual(timeout // WAIT_FOR_EXECUTION_SLEEP_INTERVAL,
+                         len(mock_time.sleep.mock_calls))
+
+    def test_passes_log_cursor(self):
+        # prepare mock status responses containing logs. The first status
+        # contains logs that end at cursor=1, so the next call needs to provide
+        # since='1'. The 2nd status has cursor=2 and 3, so the next call needs
+        # to be since='3'. The next call returns no logs at all, so since stays
+        # '3'.
+        status_responses = [
+            ClusterState({
+                'initialized': False,
+                'logs': [{'timestamp': 1, 'message': 'a', 'cursor': '1'}]
+            }),
+            ClusterState({
+                'initialized': False,
+                'logs': [{'timestamp': 1, 'message': 'a', 'cursor': '2'},
+                         {'timestamp': 1, 'message': 'a', 'cursor': '3'}]
+            }),
+            ClusterState({'initialized': False}),
+            ClusterState({
+                'initialized': True,
+                'logs': [{'timestamp': 1, 'message': 'a', 'cursor': '4'}]
+            })
+        ]
+        client = mock.Mock()
+        client.cluster.status = mock.Mock(side_effect=status_responses)
+
+        with mock.patch('cloudify_cli.commands.cluster.time'):
+            _wait_for_cluster_initialized(client, logger=mock.Mock())
+        self.assertEqual(4, len(client.cluster.status.mock_calls))
+
+        since_passed = [kw['since'] for _, _, kw in
+                        client.cluster.status.mock_calls]
+
+        self.assertEqual([None, '1', '3', '3'], since_passed)
+
+
+class ClusterStartTest(CliCommandTest):
+    def test_already_in_cluster(self):
+        self.client.cluster.status = mock.Mock(
+            return_value=ClusterState({'initialized': True}))
+        self.invoke('cfy cluster start --cluster-host-ip 1.2.3.4',
+                    'already part of a HA cluster')
+
+    def test_start_success(self):
+        self.client.cluster.status = mock.Mock(side_effect=[
+            ClusterState({'initialized': False}),
+            ClusterState({'initialized': True}),
+        ])
+        self.client.cluster.start = mock.Mock()
+        outcome = self.invoke('cfy cluster start --cluster-host-ip 1.2.3.4')
+        self.assertIn('HA cluster started', outcome.logs)
+
+    def test_start_success_with_logs(self):
+        self.client.cluster.status = mock.Mock(side_effect=[
+            ClusterState({'initialized': False}),
+            ClusterState({
+                'initialized': False,
+                'logs': [{'timestamp': 1, 'message': 'one log message',
+                          'cursor': '1'}]
+            }),
+            ClusterState({'initialized': True}),
+        ])
+        self.client.cluster.start = mock.Mock()
+        with mock.patch('cloudify_cli.commands.cluster.time'):
+            outcome = self.invoke(
+                'cfy cluster start --cluster-host-ip 1.2.3.4')
+        self.assertIn('HA cluster started', outcome.logs)
+        self.assertIn('one log message', outcome.logs)
+
+    def test_start_error(self):
+        self.client.cluster.status = mock.Mock(side_effect=[
+            ClusterState({'initialized': False}),
+            ClusterState({'error': 'some error happened'}),
+        ])
+        self.client.cluster.start = mock.Mock()
+        self.invoke('cfy cluster start --cluster-host-ip 1.2.3.4',
+                    'some error happened')


### PR DESCRIPTION
This commands starts a HA cluster on the current manager, and sets
it as the leader of the cluster.