### PR TITLE
CFY-6271 fix bootstrap import error possbile solutions

### DIFF
--- a/cloudify_cli/bootstrap/bootstrap.py
+++ b/cloudify_cli/bootstrap/bootstrap.py
@@ -155,10 +155,8 @@ def bootstrap_validation(blueprint_path,
         )
     except ImportError as e:
         e.possible_solutions = [
-            "Run 'cfy local install-plugins -p {0}'".format(
-                blueprint_path),
-            "Run 'cfy bootstrap --install-plugins -p {0}'".format(
-                blueprint_path)
+            "Run 'cfy bootstrap --install-plugins {0}'".format(blueprint_path),
+            "Run 'cfy init --install-plugins {0}'".format(blueprint_path)
         ]
         raise
 


### PR DESCRIPTION
This PR fixes Cloudify's CLI suggested solutions for a plugin import error on bootstrap.
The suggestions were adjusted to Cloudify's 4.0 CLI.
