### PR TITLE
CFY-6280 Fix snapshot list command

### DIFF
--- a/cloudify_cli/commands/snapshots.py
+++ b/cloudify_cli/commands/snapshots.py
@@ -18,7 +18,7 @@ from ..table import print_data
 from .. import utils
 from ..cli import helptexts, cfy
 
-SNAPSHOT_COLUMNS = ['id', 'created_at', 'status', 'error', 'permission'
+SNAPSHOT_COLUMNS = ['id', 'created_at', 'status', 'error', 'permission',
                     'tenant_name']
 
 


### PR DESCRIPTION
In this PR, the `cfy snapshot list` command is fixed. The problem was that a trailing comma was missing in the list of columns for the table to print in the output.