### PR TITLE
CFY-6343 Fix a bug in tenants add/remove users/user-groups

### DIFF
--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -69,7 +69,7 @@ def create(tenant_name, logger, client):
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()
-@cfy.pass_client()
+@cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
 def add_user(username, tenant_name, logger, client):
     """Add a user to a tenant
@@ -90,7 +90,7 @@ def add_user(username, tenant_name, logger, client):
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()
-@cfy.pass_client()
+@cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
 def remove_user(username, tenant_name, logger, client):
     """Remove a user from a tenant
@@ -111,7 +111,7 @@ def remove_user(username, tenant_name, logger, client):
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()
-@cfy.pass_client()
+@cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
 def add_group(user_group_name, tenant_name, logger, client):
     """Add a user group to a tenant
@@ -132,7 +132,7 @@ def add_group(user_group_name, tenant_name, logger, client):
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()
-@cfy.pass_client()
+@cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
 def remove_group(user_group_name, tenant_name, logger, client):
     """Remove a user group from a tenant


### PR DESCRIPTION
The tenant name argument would get implanted in the client headers