### PR TITLE
CFY-6412 Show only counts of users/tenants/groups when listing

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -715,6 +715,13 @@ class Options(object):
             help=helptexts.PERMISSION
         )
 
+        self.get_data = click.option(
+            '--get-data',
+            is_flag=True,
+            default=False,
+            help=helptexts.GET_DATA
+        )
+
     @staticmethod
     def include_keys(help):
         return click.option(

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -224,3 +224,8 @@ LDAP_DOMAIN = 'The LDAP domain to be used by the server'
 LDAP_IS_ACTIVE_DIRECTORY = 'Specify whether the LDAP used for authentication' \
                            ' is Active-Directory.'
 LDAP_DN_EXTRA = 'Extra LDAP DN options.'
+
+GET_DATA = 'When set to True, displays the full list of connected resources ' \
+           '(users/tenants/user-groups), for each listed resource. When set ' \
+           'to False displays the total number of connected resources. ' \
+           '(default:False)'

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -36,14 +36,19 @@ def tenants():
 @cfy.options.sort_by('name')
 @cfy.options.descending
 @cfy.options.verbose()
+@cfy.options.get_data
 @cfy.assert_manager_active()
 @cfy.pass_client()
 @cfy.pass_logger
-def list(sort_by, descending, logger, client):
+def list(sort_by, descending, get_data, logger, client):
     """List all tenants
     """
     logger.info('Listing all tenants...')
-    tenants_list = client.tenants.list(sort=sort_by, is_descending=descending)
+    tenants_list = client.tenants.list(
+        sort=sort_by,
+        is_descending=descending,
+        _get_data=get_data
+    )
     print_data(TENANT_COLUMNS, tenants_list, 'Tenants:')
 
 
@@ -152,15 +157,16 @@ def remove_group(user_group_name, tenant_name, logger, client):
 @cfy.argument('tenant-name')
 @cfy.options.verbose()
 @cfy.assert_manager_active()
+@cfy.options.get_data
 @cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
-def get(tenant_name, logger, client):
+def get(tenant_name, get_data, logger, client):
     """Get details for a single tenant
 
     `TENANT_NAME` is the name of the tenant
     """
     logger.info('Getting info for tenant `{0}`...'.format(tenant_name))
-    tenant_details = client.tenants.get(tenant_name)
+    tenant_details = client.tenants.get(tenant_name, _get_data=get_data)
     print_data(TENANT_COLUMNS, tenant_details, 'Requested tenant info:')
 
 

--- a/cloudify_cli/commands/user_groups.py
+++ b/cloudify_cli/commands/user_groups.py
@@ -36,15 +36,19 @@ def user_groups():
 @cfy.options.sort_by('name')
 @cfy.options.descending
 @cfy.options.verbose()
+@cfy.options.get_data
 @cfy.assert_manager_active()
 @cfy.pass_client()
 @cfy.pass_logger
-def list(sort_by, descending, logger, client):
+def list(sort_by, descending, get_data, logger, client):
     """List all user groups
     """
     logger.info('Listing all user groups...')
-    user_groups_list = client.user_groups.list(sort=sort_by,
-                                               is_descending=descending)
+    user_groups_list = client.user_groups.list(
+        sort=sort_by,
+        is_descending=descending,
+        _get_data=get_data
+    )
     print_data(GROUP_COLUMNS, user_groups_list, 'User groups:')
 
 
@@ -71,16 +75,20 @@ def create(user_group_name, ldap_distinguished_name, logger, client):
                                 'user group [manager only]')
 @cfy.argument('user-group-name')
 @cfy.options.verbose()
+@cfy.options.get_data
 @cfy.assert_manager_active()
 @cfy.pass_client()
 @cfy.pass_logger
-def get(user_group_name, logger, client):
+def get(user_group_name, get_data, logger, client):
     """Get details for a single user group
 
     `USER_GROUP_NAME` is the name of the user group
     """
     logger.info('Getting info for user group `{0}`...'.format(user_group_name))
-    user_group_details = client.user_groups.get(user_group_name)
+    user_group_details = client.user_groups.get(
+        user_group_name,
+        _get_data=get_data
+    )
     print_data(GROUP_COLUMNS, user_group_details, 'Requested user group info:')
 
 

--- a/cloudify_cli/commands/users.py
+++ b/cloudify_cli/commands/users.py
@@ -35,14 +35,19 @@ def users():
 @cfy.options.sort_by('username')
 @cfy.options.descending
 @cfy.options.verbose()
+@cfy.options.get_data
 @cfy.assert_manager_active()
 @cfy.pass_client()
 @cfy.pass_logger
-def list(sort_by, descending, logger, client):
+def list(sort_by, descending, get_data, logger, client):
     """List all users
     """
     logger.info('Listing all users...')
-    users_list = client.users.list(sort=sort_by, is_descending=descending)
+    users_list = client.users.list(
+        sort=sort_by,
+        is_descending=descending,
+        _get_data=get_data
+    )
     print_data(USER_COLUMNS, users_list, 'Users:')
 
 
@@ -103,16 +108,17 @@ def set_role(username, security_role, logger, client):
                short_help='Get details for a single user [manager only]')
 @cfy.argument('username')
 @cfy.options.verbose()
+@cfy.options.get_data
 @cfy.assert_manager_active()
 @cfy.pass_client()
 @cfy.pass_logger
-def get(username, logger, client):
+def get(username, get_data, logger, client):
     """Get details for a single user
 
     `USERNAME` is the username of the user
     """
     logger.info('Getting info for user `{0}`...'.format(username))
-    user_details = client.users.get(username)
+    user_details = client.users.get(username, _get_data=get_data)
     print_data(USER_COLUMNS, user_details, 'Requested user info:')
 
 


### PR DESCRIPTION
When running `cfy tenants/users/user-groups list` the default behavior would be to show the count of connected models (e.g. if running `cfy tenants list` and some tenant has 3 users and 2 groups connected to it, the output would be to only show those numbers instead of the actual users/groups connected).
It is still possible to get the old behavior by adding the `--get-data` flag.