### PR TITLE
CFY-6479 Map error_causes to task_error_causes

### DIFF
--- a/cloudify_cli/execution_events_fetcher.py
+++ b/cloudify_cli/execution_events_fetcher.py
@@ -90,12 +90,18 @@ class ExecutionEventsFetcher(object):
         }
         for context_field in self.CONTEXT_FIELDS:
             del event[context_field]
+
         event['context']['node_id'] = event['node_instance_id']
         del event['node_instance_id']
+
         event['message'] = {
             'arguments': None,
             'text': event['message'],
         }
+
+        event['context']['task_error_causes'] = event['error_causes']
+        del event['error_causes']
+
         return event
 
     def fetch_and_process_events(self, events_handler=None, timeout=60):

--- a/cloudify_cli/tests/commands/test_deployments.py
+++ b/cloudify_cli/tests/commands/test_deployments.py
@@ -192,6 +192,7 @@ class DeploymentsTest(CliCommandTest):
             'type': 'foo',
             'timestamp': '12345678',
             'message': 'workflow execution succeeded',
+            'error_causes': '<error_causes>',
             'deployment_id': 'deployment-id',
             'execution_id': '<execution_id>',
             'node_name': '<node_name>',

--- a/cloudify_cli/tests/commands/test_events.py
+++ b/cloudify_cli/tests/commands/test_events.py
@@ -43,6 +43,7 @@ class EventsTest(CliCommandTest):
                 'workflow_id': '<workflow_id>',
                 'type': event_type,
                 'message': '<message>',
+                'error_causes': '<error_causes>',
             }
             events.append((event_time, event))
             event_time += 0.3
@@ -59,6 +60,7 @@ class EventsTest(CliCommandTest):
             'workflow_id': '<workflow_id>',
             'type': 'cloudify_event',
             'message': '<message>',
+            'error_causes': '<error_causes>',
         }
         events.append((end_time, success_event))
         return events

--- a/cloudify_cli/tests/test_env.py
+++ b/cloudify_cli/tests/test_env.py
@@ -558,6 +558,7 @@ class ExecutionEventsFetcherTest(CliCommandTest):
                 'workflow_id': '<workflow_id>',
                 'node_instance_id': '<node_instance_id>',
                 'message': '<message>',
+                'error_causes': '<error_causes>',
             }
             for _ in xrange(count)
         ]
@@ -728,6 +729,7 @@ class WaitForExecutionTests(CliCommandTest):
                 'workflow_id': '<workflow_id>',
                 'node_instance_id': '<node_instance_id>',
                 'message': '<message>',
+                'error_causes': '<error_causes>',
                 'event_type': 'workflow_succeeded',
             }], 1)],
             repeat(MockListResponse([], 0))
@@ -767,6 +769,7 @@ class WaitForExecutionTests(CliCommandTest):
                 'workflow_id': '<workflow_id>',
                 'node_instance_id': '<node_instance_id>',
                 'message': '<message>',
+                'error_causes': '<error_causes>',
                 'event_type': 'workflow_succeeded',
             }], 1)],
             repeat(MockListResponse([], 0))


### PR DESCRIPTION
The database field is called `error_causes`, but the implementation that
use the AMQP event structure expect the `task_error_causes` field.

Related:  cloudify-cosmo/cloudify-manager-blueprints#540