### PR TITLE
CFY 6722. Allow multiple local blueprints by default

### DIFF
--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -45,7 +45,8 @@ CLOUDIFY_WORKDIR = os.path.join(
     constants.CLOUDIFY_BASE_DIRECTORY_NAME)
 PROFILES_DIR = os.path.join(CLOUDIFY_WORKDIR, 'profiles')
 ACTIVE_PRO_FILE = os.path.join(CLOUDIFY_WORKDIR, 'active.profile')
-MULTIPLE_LOCAL_BLUEPRINTS = os.environ.get('CFY_MULTIPLE_BLUEPRINTS') == 'true'
+MULTIPLE_LOCAL_BLUEPRINTS = (
+    os.environ.get('CFY_MULTIPLE_BLUEPRINTS', 'true') == 'true')
 CLUSTER_RETRY_INTERVAL = 5
 
 

--- a/cloudify_cli/tests/test_env.py
+++ b/cloudify_cli/tests/test_env.py
@@ -1194,18 +1194,13 @@ class TestLocal(CliCommandTest):
         )
 
     def test_initialize_blueprint_default_multi_env(self):
-        # Simulate the case when env.MULTIPLE_LOCAL_BLUEPRINTS == True
-        original_storage_dir = cli_local._STORAGE_DIR_NAME
-        cli_local._STORAGE_DIR_NAME = ''
-        try:
-            self._test_initialize_blueprint(
-                name='test',
-                custom_inputs={},
-                expected_inputs=TestLocal._DEFAULT_INPUTS,
-                expected_storage_dir='/tmp/.cloudify-test/profiles/local/test'
-            )
-        finally:
-            cli_local._STORAGE_DIR_NAME = original_storage_dir
+        """Initialize blueprint with multiple local blueprints enabled."""
+        self._test_initialize_blueprint(
+            name='test',
+            custom_inputs={},
+            expected_inputs=TestLocal._DEFAULT_INPUTS,
+            expected_storage_dir='/tmp/.cloudify-test/profiles/local/test'
+        )
 
     def _test_initialize_blueprint(self,
                                    name,

--- a/cloudify_cli/tests/test_env.py
+++ b/cloudify_cli/tests/test_env.py
@@ -1173,8 +1173,6 @@ class TestLocal(CliCommandTest):
             name='local',
             custom_inputs={},
             expected_inputs=TestLocal._DEFAULT_INPUTS,
-            expected_storage_dir='/tmp/.cloudify-test/profiles/local/'
-                                 'local-storage/local'
         )
 
     def test_initialize_blueprint_custom_single_env(self):
@@ -1189,8 +1187,6 @@ class TestLocal(CliCommandTest):
             name='temp',
             custom_inputs=custom_inputs,
             expected_inputs=custom_inputs,
-            expected_storage_dir='/tmp/.cloudify-test/profiles/local/'
-                                 'local-storage/temp'
         )
 
     def test_initialize_blueprint_default_multi_env(self):
@@ -1199,14 +1195,12 @@ class TestLocal(CliCommandTest):
             name='test',
             custom_inputs={},
             expected_inputs=TestLocal._DEFAULT_INPUTS,
-            expected_storage_dir='/tmp/.cloudify-test/profiles/local/test'
         )
 
     def _test_initialize_blueprint(self,
                                    name,
                                    custom_inputs,
-                                   expected_inputs,
-                                   expected_storage_dir):
+                                   expected_inputs):
         environment = cli_local.initialize_blueprint(
             TestLocal._BLUEPRINT_PATH,
             name,
@@ -1215,11 +1209,6 @@ class TestLocal(CliCommandTest):
         self.assertEqual(environment.name, name)
         self.assertEqual(environment.plan['inputs'], expected_inputs)
         self.assertIn('mock_workflow', environment.plan['workflows'])
-        # TODO: Figure out where _storage_dir was taken from
-        # self.assertEqual(
-        #     environment.storage._storage_dir,
-        #     expected_storage_dir
-        # )
 
 
 class TestClusterRestClient(CliCommandTest):


### PR DESCRIPTION
In this PR, multiple local blueprints is activated by default, meaning that it's possible to orchestrate locally multiple blueprints without having to connect the client to a manager.