### PR TITLE
CFY-6836. Add multiple local profiles test cases

### DIFF
--- a/cloudify_cli/local.py
+++ b/cloudify_cli/local.py
@@ -34,7 +34,6 @@ from .config.config import CloudifyConfig
 
 
 _ENV_NAME = 'local'
-_STORAGE_DIR_NAME = '' if env.MULTIPLE_LOCAL_BLUEPRINTS else 'local-storage'
 
 
 def initialize_blueprint(blueprint_path,
@@ -69,7 +68,10 @@ def storage_dir(blueprint_id=None):
             blueprint_id
         )
     else:
-        return os.path.join(env.PROFILES_DIR, _ENV_NAME, _STORAGE_DIR_NAME)
+        directories = [env.PROFILES_DIR, _ENV_NAME]
+        if not env.MULTIPLE_LOCAL_BLUEPRINTS:
+            directories.append('local-storage')
+        return os.path.join(*directories)
 
 
 def get_storage():

--- a/cloudify_cli/tests/__init__.py
+++ b/cloudify_cli/tests/__init__.py
@@ -6,6 +6,5 @@ from ..config import config
 env.CLOUDIFY_WORKDIR = '/tmp/.cloudify-test'
 env.PROFILES_DIR = os.path.join(env.CLOUDIFY_WORKDIR, 'profiles')
 env.ACTIVE_PRO_FILE = os.path.join(env.CLOUDIFY_WORKDIR, 'active.profile')
-env.MULTIPLE_LOCAL_BLUEPRINTS = False
 
 config.CLOUDIFY_CONFIG_PATH = os.path.join(env.CLOUDIFY_WORKDIR, 'config.yaml')

--- a/cloudify_cli/tests/commands/test_executions.py
+++ b/cloudify_cli/tests/commands/test_executions.py
@@ -83,22 +83,30 @@ class ExecutionsTest(CliCommandTest):
     def test_local_execution_default_param(self):
         self._init_local_env()
         self._assert_outputs({'param': 'null'})
-        self.invoke('cfy executions start {0}'.format('run_test_op_on_nodes'))
+        self.invoke(
+            'cfy executions start {0} '
+            '-b local'
+            .format('run_test_op_on_nodes'))
         self._assert_outputs({'param': 'default_param'})
 
     def test_local_execution_custom_param_value(self):
         self._init_local_env()
-        self.invoke('cfy executions start {0} -p param=custom_value'.format(
-            'run_test_op_on_nodes')
+        self.invoke(
+            'cfy executions start {0} '
+            '-b local '
+            '-p param=custom_value'
+            .format('run_test_op_on_nodes')
         )
         self._assert_outputs({'param': 'custom_value'})
 
     def test_local_execution_allow_custom_params(self):
         self._init_local_env()
-        self.invoke('cfy executions start {0} '
-                    '-p custom_param=custom_value --allow-custom-parameters'
-                    ''.format('run_test_op_on_nodes')
-                    )
+        self.invoke(
+            'cfy executions start {0} '
+            '-b local '
+            '-p custom_param=custom_value --allow-custom-parameters'
+            .format('run_test_op_on_nodes')
+        )
         self._assert_outputs(
             {'param': 'default_param', 'custom_param': 'custom_value'}
         )
@@ -106,9 +114,10 @@ class ExecutionsTest(CliCommandTest):
     def test_local_execution_dont_allow_custom_params(self):
         self._init_local_env()
         self.invoke(
-            'cfy executions start {0} -p custom_param=custom_value'.format(
-                'run_test_op_on_nodes'
-            ),
+            'cfy executions start {0} '
+            '-b local '
+            '-p custom_param=custom_value'
+            .format('run_test_op_on_nodes'),
             err_str_segment='Workflow "run_test_op_on_nodes" does not '
                             'have the following parameters declared: '
                             'custom_param',
@@ -116,7 +125,8 @@ class ExecutionsTest(CliCommandTest):
         )
 
     def _assert_outputs(self, expected_outputs):
-        output = self.invoke('cfy deployments outputs').logs.split('\n')
+        output = self.invoke(
+            'cfy deployments outputs -b local').logs.split('\n')
         for key, value in expected_outputs.iteritems():
             if value == 'null':
                 key_val_string = '  "{0}": {1}, '.format(key, value)

--- a/cloudify_cli/tests/commands/test_init.py
+++ b/cloudify_cli/tests/commands/test_init.py
@@ -75,7 +75,8 @@ class InitTest(CliCommandTest):
         self.invoke('cfy init {0}'.format(blueprint_path))
         cfy.register_commands()
 
-        output = self.invoke('cfy deployments outputs').logs.split('\n')
+        output = self.invoke(
+            'cfy deployments outputs -b local').logs.split('\n')
         self.assertIn('  "key1": "default_val1", ', output)
         self.assertIn('  "key2": "default_val2", ', output)
         self.assertIn('  "key3": "default_val3", ', output)
@@ -94,7 +95,8 @@ class InitTest(CliCommandTest):
         self.invoke(command)
         cfy.register_commands()
 
-        output = self.invoke('cfy deployments inputs').logs.split('\n')
+        output = self.invoke(
+            'cfy deployments inputs -b local').logs.split('\n')
         self.assertIn('  "key1": "default_val1", ', output)
         self.assertIn('  "key2": "default_val2", ', output)
         self.assertIn('  "key3": "default_val3"', output)
@@ -113,7 +115,8 @@ class InitTest(CliCommandTest):
         self.invoke(command)
         cfy.register_commands()
 
-        output = self.invoke('cfy deployments inputs').logs.split('\n')
+        output = self.invoke(
+            'cfy deployments inputs -b local').logs.split('\n')
         self.assertIn('  "key1": "val1", ', output)
         self.assertIn('  "key2": "val2", ', output)
         self.assertIn('  "key3": "val3"', output)
@@ -188,12 +191,13 @@ class InitTest(CliCommandTest):
 
     def test_init_blueprint_archive(self):
         self.invoke(
-            'cfy init {0} -n simple_blueprint.yaml'
+            'cfy init {0} -b local -n simple_blueprint.yaml'
             .format(SAMPLE_CUSTOM_NAME_ARCHIVE)
         )
         cfy.register_commands()
 
-        output = self.invoke('cfy deployments inputs').logs.split('\n')
+        output = self.invoke(
+            'cfy deployments inputs -b local').logs.split('\n')
         self.assertIn('  "key1": "default_val1", ', output)
         self.assertIn('  "key2": "default_val2", ', output)
         self.assertIn('  "key3": "default_val3"', output)

--- a/cloudify_cli/tests/commands/test_node_instances.py
+++ b/cloudify_cli/tests/commands/test_node_instances.py
@@ -39,18 +39,19 @@ class NodeInstancesTest(CliCommandTest):
 
     def test_local_instances(self):
         self._create_local_env()
-        output = self.invoke('cfy node-instances', context='local')
+        output = self.invoke('cfy node-instances -b local', context='local')
         self._assert_outputs(output, {'node_id': 'node'})
 
     def test_local_instances_with_existing_node_id(self):
         self._create_local_env()
-        output = self.invoke('cfy node-instances node', context='local')
+        output = self.invoke(
+            'cfy node-instances -b local node', context='local')
         self._assert_outputs(output, {'node_id': 'node'})
 
     def test_local_instances_with_non_existing_node_id(self):
         self._create_local_env()
         self.invoke(
-            'cfy node-instances noop', context='local',
+            'cfy node-instances -b local noop', context='local',
             err_str_segment='Could not find node noop'
         )
 
@@ -63,7 +64,10 @@ class NodeInstancesTest(CliCommandTest):
 
         self.invoke('cfy init {0}'.format(blueprint_path))
         cfy.register_commands()
-        self.invoke('cfy executions start {0}'.format('run_test_op_on_nodes'))
+        self.invoke(
+            'cfy executions start -b local {0}'
+            .format('run_test_op_on_nodes')
+        )
 
     def _assert_outputs(self, output, expected_outputs):
         output = output.logs.split('\n')

--- a/cloudify_cli/tests/commands/test_uninstall.py
+++ b/cloudify_cli/tests/commands/test_uninstall.py
@@ -114,14 +114,14 @@ class UninstallTest(CliCommandTest):
             DEFAULT_BLUEPRINT_FILE_NAME
         )
         self.invoke('cfy init {0}'.format(blueprint_path))
-        self.invoke('cfy uninstall', context='local')
+        self.invoke('cfy uninstall -b local', context='local')
 
         args = local_start_mock.call_args_list[0][1]
         self.assertDictEqual(
             args,
             {
                 'parameters': DEFAULT_PARAMETERS,
-                'blueprint_id': None,
+                'blueprint_id': 'local',
                 'allow_custom_parameters': False,
                 'workflow_id': 'uninstall',
                 'task_retries': 0,
@@ -139,6 +139,7 @@ class UninstallTest(CliCommandTest):
         )
         self.invoke('cfy init {0}'.format(blueprint_path))
         self.invoke('cfy uninstall'
+                    ' -b local'
                     ' -w my_uninstall'
                     ' --parameters key=value'
                     ' --allow-custom-parameters'
@@ -152,7 +153,7 @@ class UninstallTest(CliCommandTest):
             args,
             {
                 'parameters': {u'key': u'value'},
-                'blueprint_id': None,
+                'blueprint_id': 'local',
                 'allow_custom_parameters': True,
                 'workflow_id': u'my_uninstall',
                 'task_retries': 14,
@@ -167,14 +168,19 @@ class UninstallTest(CliCommandTest):
             'local',
             DEFAULT_BLUEPRINT_FILE_NAME
         )
+        storage_dir = os.path.join(local.storage_dir(), 'local')
 
         # Using run_test_op_on_nodes because the blueprint doesn't have
         # install/uninstall workflows
         self.invoke(
-            'cfy install {0} -w run_test_op_on_nodes'.format(blueprint_path),
+            'cfy install {0} -b local -w run_test_op_on_nodes'
+            .format(blueprint_path),
             context='local'
         )
-        self.assertTrue(os.path.isdir(local.storage_dir()))
+        self.assertTrue(os.path.isdir(storage_dir))
 
-        self.invoke('cfy uninstall -w run_test_op_on_nodes', context='local')
-        self.assertFalse(os.path.isdir(local.storage_dir()))
+        self.invoke(
+            'cfy uninstall -b local -w run_test_op_on_nodes',
+            context='local',
+        )
+        self.assertFalse(os.path.isdir(storage_dir))

--- a/cloudify_cli/tests/test_env.py
+++ b/cloudify_cli/tests/test_env.py
@@ -1160,7 +1160,7 @@ class TestLocal(CliCommandTest):
     def test_storage_dir(self):
         self.assertEqual(
             cli_local.storage_dir(),
-            '/tmp/.cloudify-test/profiles/local/local-storage'
+            '/tmp/.cloudify-test/profiles/local'
         )
 
         self.assertEqual(

--- a/cloudify_cli/tests/test_multiple_local_profiles.py
+++ b/cloudify_cli/tests/test_multiple_local_profiles.py
@@ -1,0 +1,80 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+############
+
+import os
+import shutil
+
+from .. import env
+from . import cfy
+from .commands.constants import (
+    BLUEPRINTS_DIR,
+    DEFAULT_BLUEPRINT_FILE_NAME,
+)
+from testtools import TestCase
+from testtools.matchers import DirExists
+
+
+class TestMultipleLocalProfiles(TestCase):
+
+    """Verify that multple local profiles can be used."""
+
+    LOCAL_BLUEPRINT_PATH = os.path.join(
+        BLUEPRINTS_DIR,
+        'local',
+        DEFAULT_BLUEPRINT_FILE_NAME,
+    )
+
+    LOCAL_PROFILE_DIR = os.path.join(env.PROFILES_DIR, 'local')
+
+    def tearDown(self):
+        """Delete cloudify data directory."""
+        super(TestMultipleLocalProfiles, self).tearDown()
+        shutil.rmtree(env.CLOUDIFY_WORKDIR)
+
+    def test_default_blueprint_id(self):
+        """Default blueprint id is the directory name."""
+        cfy.invoke('init {0}'.format(self.LOCAL_BLUEPRINT_PATH))
+        self.assertThat(
+            os.path.join(self.LOCAL_PROFILE_DIR, 'local'),
+            DirExists(),
+        )
+
+    def test_blueprint_id(self):
+        """Blueprint id passed as argument is used."""
+        cfy.invoke(
+            'init -b my-blueprint {0}'.format(self.LOCAL_BLUEPRINT_PATH))
+        self.assertThat(
+            os.path.join(self.LOCAL_PROFILE_DIR, 'my-blueprint'),
+            DirExists(),
+        )
+
+    def test_multiple_blueprints(self):
+        """Multiple blueprints with different id can coexist."""
+        blueprint_count = 5
+
+        for blueprint_number in xrange(blueprint_count):
+            cfy.invoke(
+                'init -b my-blueprint-{0} {1}'
+                .format(blueprint_number, self.LOCAL_BLUEPRINT_PATH)
+            )
+        for blueprint_number in xrange(blueprint_count):
+            self.assertThat(
+                os.path.join(
+                    self.LOCAL_PROFILE_DIR,
+                    'my-blueprint-{0}'.format(blueprint_number),
+                ),
+                DirExists(),
+            )


### PR DESCRIPTION
In this PR, a few test cases have been added to verify that the multiple local profiles feature works as expected.

In addition to this, the testing environment is updated to enable multiple local profiles by default to match the current implementation. This requires to update test cases to add a missing blueprint parameter that wasn't needed when the default was to use a single local profile. 