### PR TITLE
CFY-6901 When setting the active profile, also set it in-process

### DIFF
--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -262,7 +262,6 @@ def set(profile_name,
                                    .format(profile_name))
         old_name = env.profile.profile_name
         env.profile.profile_name = profile_name
-        env.set_active_profile(profile_name)
     if manager_username:
         logger.info('Setting username to `{0}`'.format(manager_username))
         env.profile.manager_username = manager_username
@@ -275,6 +274,7 @@ def set(profile_name,
 
     env.profile.save()
     if old_name is not None:
+        env.set_active_profile(profile_name)
         env.delete_profile(old_name)
     logger.info('Settings saved successfully')
 

--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -74,8 +74,10 @@ def assert_profile_exists(profile_name):
 
 
 def set_active_profile(profile_name):
+    global profile
     with open(ACTIVE_PRO_FILE, 'w+') as active_profile:
         active_profile.write(profile_name)
+    profile = get_profile_context(profile_name, suppress_error=True)
 
 
 def get_active_profile():


### PR DESCRIPTION
`set_active_profile`, instead of just writing to the active.profile
file, will now set `env.profile = active_profile` as well.

This is done using the global keyword so it is somewhat dirty, but we
are using the profile as a global after all.

This is because bootstrap creates and sets a new profile, so the rest
of bootstrap code should be able to use that profile. Specifically,
without this change, the get_rest_client call will still use the
previous (non-temp, whatever profile was active before) profile,
and if that previous active profile had a cluster, then it'll try
to use the cluster client.