### PR TITLE
CFY-6906 Use the profile manager_ip for cfy --version display

### DIFF
--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -350,7 +350,7 @@ def get_manager_version_data(rest_client=None):
         version_data = rest_client.manager.get_version()
     except CloudifyClientError:
         return None
-    version_data['ip'] = rest_client.host
+    version_data['ip'] = profile.manager_ip
     return version_data
 
 


### PR DESCRIPTION
Using rest_client.host isn't enough because that just shows the
original ip in a cluster profile. Instead, we want the ip of the
server that actually is active, and the rest client will update the
profile accordingly