### PR TITLE
CFY-7081 When setting verbosity, don't lose the value

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -181,6 +181,7 @@ def set_verbosity_level(ctx, param, value):
         return
 
     set_global_verbosity_level(value)
+    return value
 
 
 def set_cli_except_hook(global_verbosity_level):


### PR DESCRIPTION
set_cli_except_hook expects the verbosity value, it needs to be
passed down from set_verbosity_level via main.
Otherwise it's just lost.