### PR TITLE
CFY-7106 Fetch events sorted by reported timestamp by default

### DIFF
--- a/cloudify_cli/execution_events_fetcher.py
+++ b/cloudify_cli/execution_events_fetcher.py
@@ -62,7 +62,7 @@ class ExecutionEventsFetcher(object):
             _offset=self._from_event,
             _size=self._batch_size,
             include_logs=self._include_logs,
-            sort='@timestamp').items
+            sort='reported_timestamp').items
         self._from_event += len(events)
         return [
             self._map_api_event_to_internal_event(event)


### PR DESCRIPTION
In this PR, the problem of logs out of order is fixed by using `reported_timestamp`
as the sort column instead of `timestamp` for the events retrieved by the CLI using the REST client.

Data flow analysis:
- the events were sent in the right order from the management worker to rabbitmq,
- were delivered by rabbitmq in the right order to logstash
- logstash was inserting them in the database in the right order
- the cli failed to get the events in the right order because sorting by `timestamp` just doesn't work when the events being considered have the same timestamp value since they are inserted by logstash into the database in the same batch.

Timestamp values explanation:
 - `timestamp` is a value generated when an event is inserted into the database.
- `reported_timestamp` is generated when the event is sent to the message queue.

Hence:
- events inserted in the same logstash batch have the same timestamp.
- events for the same host should have a different `reported_timestamp` value since they are sent to the message queue at different times (even in this case where a loop is involved)