### PR TITLE
CFY-7103 Pass inputs to start/join to allow configuration

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -795,6 +795,14 @@ class Options(object):
             required=False,
             help=helptexts.SECRET_FILE)
 
+        # same as --inputs, name changed for consistency
+        self.cluster_node_options = click.option(
+            '-o',
+            '--options',
+            multiple=True,
+            callback=inputs_callback,
+            help=helptexts.CLUSTER_NODE_OPTIONS)
+
     @staticmethod
     def include_keys(help):
         return click.option(

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -237,3 +237,5 @@ PROFILE_NAME = 'Name of the profile to use'
 SECRET_VALUE = "The secret's value to be set"
 SECRET_STRING = "The string to use as the secret's value"
 SECRET_FILE = "The secret's file to use its content as value to be set"
+CLUSTER_NODE_OPTIONS = 'Additional options for the cluster node '\
+                       'configuration {0}'.format(INPUTS_PARAMS_USAGE)


### PR DESCRIPTION
Port of #524 

* CFY-6009 Pass inputs to start/join to allow configuration

* Add `cfy cluster nodes update`

* Change --inputs to --options

* Pretty print options

* YAML-style options in `cfy cluster nodes get`

* Change table header in `cluster nodes get`

* 'Node configuration' instead of 'Node options'