### PR TITLE
CFY-7231 Remove from cluster removes from profile

### DIFF
--- a/cloudify_cli/commands/cluster.py
+++ b/cloudify_cli/commands/cluster.py
@@ -389,12 +389,25 @@ def remove_node(client, logger, cluster_node_name):
     if cluster_node_name not in cluster_nodes:
         raise CloudifyCliError('Invalid command. {0} is not a member of '
                                'the cluster.'.format(cluster_node_name))
+    removed_node_ip = cluster_nodes[cluster_node_name]
 
     client.cluster.nodes.delete(cluster_node_name)
 
-    env.profile.cluster = [node for node in env.profile.cluster
-                           if node['name'] != cluster_node_name]
-    env.profile.save()
+    for profile_name in env.get_profile_names():
+        profile_context = env.get_profile_context(profile_name)
+
+        if profile_context.profile_name == removed_node_ip:
+            logger.info('Profile {0} set as a non-cluster profile'
+                        .format(profile_context.profile_name))
+            profile_context.cluster = None
+        else:
+            logger.info(
+                'Profile {0}: {1} removed from cluster nodes list'
+                .format(profile_context.profile_name, cluster_node_name))
+            profile_context.cluster = [node for node in profile_context.cluster
+                                       if node['name'] != cluster_node_name]
+        profile_context.save()
+
     logger.info('Node {0} was removed successfully!'
                 .format(cluster_node_name))
 
@@ -405,6 +418,7 @@ def _join_node_to_profile(node_name, from_profile, joined_profile=None):
     node = {node_attr: getattr(from_profile, node_attr)
             for node_attr in env.CLUSTER_NODE_ATTRS}
     cert_file = env.get_ssl_cert()
+    from_profile.save()
     if cert_file:
         profile_cert = os.path.join(
             joined_profile.workdir,

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -84,7 +84,7 @@ def list(logger):
     current_profile = env.get_active_profile()
 
     profiles = []
-    profile_names = _get_profile_names()
+    profile_names = env.get_profile_names()
     for profile in profile_names:
         profile_data = _get_profile(profile)
         if profile == current_profile:
@@ -202,7 +202,7 @@ def purge_incomplete(logger):
     """Purge all profiles for which the bootstrap state is incomplete
     """
     logger.info('Purging incomplete bootstrap profiles...')
-    profile_names = _get_profile_names()
+    profile_names = env.get_profile_names()
     for profile in profile_names:
         context = env.get_profile_context(profile)
         if context.bootstrap_state == 'Incomplete':
@@ -411,7 +411,7 @@ def export_profiles(include_keys, output_path, logger):
     # TODO: Copy exported ssh keys to each profile's directory
     logger.info('Exporting profiles to {0}...'.format(destination))
     if include_keys:
-        for profile in _get_profile_names():
+        for profile in env.get_profile_names():
             _backup_ssh_key(profile)
     utils.tar(env.PROFILES_DIR, destination)
     if include_keys:
@@ -443,7 +443,7 @@ def import_profiles(archive_path, include_keys, logger):
     utils.untar(archive_path, os.path.dirname(env.PROFILES_DIR))
 
     if include_keys:
-        for profile in _get_profile_names():
+        for profile in env.get_profile_names():
             _restore_ssh_key(profile)
     else:
         if EXPORTED_KEYS_DIRNAME in os.listdir(env.PROFILES_DIR):
@@ -457,7 +457,7 @@ def import_profiles(archive_path, include_keys, logger):
 
 
 def _assert_profiles_exist():
-    if not _get_profile_names():
+    if not env.get_profile_names():
         raise CloudifyCliError('No profiles to export')
 
 
@@ -472,16 +472,6 @@ def _assert_profiles_archive(archive_path):
 def _assert_is_tarfile(archive_path):
     if not tarfile.is_tarfile(archive_path):
         raise CloudifyCliError('The archive provided must be a tar.gz archive')
-
-
-def _get_profile_names():
-    # TODO: This is too.. ambiguous. We should change it so there are
-    # no exclusions.
-    excluded = ['local', EXPORTED_KEYS_DIRNAME]
-    profile_names = [item for item in os.listdir(env.PROFILES_DIR)
-                     if item not in excluded]
-
-    return profile_names
 
 
 def _backup_ssh_key(profile):

--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -90,6 +90,16 @@ def get_active_profile():
         return None
 
 
+def get_profile_names():
+    # TODO: This is too.. ambiguous. We should change it so there are
+    # no exclusions.
+    excluded = ['local']
+    profile_names = [item for item in os.listdir(PROFILES_DIR)
+                     if item not in excluded and not item.startswith('.')]
+
+    return profile_names
+
+
 def assert_manager_active():
     if not is_manager_active():
         raise CloudifyCliError(


### PR DESCRIPTION
When we use `cfy cluster nodes remove`, all the relevant profiles are updated:
  - all the profiles that are connected to that cluster remove 
    node from their cluster list
  - all the profiles for that node can remove their cluster list entirely

This allows (together with #665) to `cfy use` the profile of that node, which
will allow doing ssh-related tasks on it (eg. teardown).