### PR TITLE
CFY-7253: remove ssl redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,5 @@ docs/_build/
 .DS_Store
 
 .idea/
+.cloudify/
 

--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -635,8 +635,14 @@ class Options(object):
         self.rest_port = click.option(
             '--rest-port',
             required=False,
-            default=constants.DEFAULT_REST_PORT,
             help=helptexts.REST_PORT)
+
+        self.ssl_rest = click.option(
+            '--ssl',
+            is_flag=True,
+            required=False,
+            default=False,
+            help=helptexts.SSL_REST)
 
         self.init_hard_reset = click.option(
             '--hard',

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -160,6 +160,7 @@ MANAGER_TENANT = 'The tenant associated with the current user operating the ' \
                  'manager'
 SSL_STATE = 'Required SSL state (on/off)'
 REST_PORT = "The REST server's port"
+SSL_REST = "Connect to REST server using SSL"
 REST_CERT = "The REST server's external certificate file location"
 
 EXPORT_SSH_KEYS = 'Include ssh key files in archive'

--- a/cloudify_cli/tests/commands/test_profiles.py
+++ b/cloudify_cli/tests/commands/test_profiles.py
@@ -9,7 +9,6 @@ from mock import MagicMock, patch
 from .. import cfy
 from ... import env
 from ... import utils
-from ... import constants
 from ...commands import profiles
 from .test_base import CliCommandTest
 
@@ -334,9 +333,6 @@ class ProfilesTest(CliCommandTest):
 
     @patch('cloudify_cli.commands.profiles._get_provider_context',
            return_value={})
-    @patch('cloudify_cli.commands.profiles._get_rest_port_and_protocol',
-           return_value={constants.DEFAULT_REST_PORT,
-                         constants.DEFAULT_REST_PROTOCOL})
     def test_use_defaults_ip_to_profile_name(self, *_):
         outcome = self.invoke('profiles use 1.2.3.4')
         self.assertIn('Using manager 1.2.3.4', outcome.logs)
@@ -346,9 +342,6 @@ class ProfilesTest(CliCommandTest):
 
     @patch('cloudify_cli.commands.profiles._get_provider_context',
            return_value={})
-    @patch('cloudify_cli.commands.profiles._get_rest_port_and_protocol',
-           return_value={constants.DEFAULT_REST_PORT,
-                         constants.DEFAULT_REST_PROTOCOL})
     def test_use_sets_provided_manager_ip(self, *_):
         outcome = self.invoke('profiles use 1.2.3.4 --profile-name 5.6.7.8')
         self.assertIn('Using manager 1.2.3.4', outcome.logs)


### PR DESCRIPTION
* Added `--secured` switch to `cfy profiles use`
* Removed dummy `status` request for the purpose of determining protocol & port
* Protocol is `https` if `--secured` is specified, `http` otherwise
* If `--rest-port` is provided, it is used. Otherwise, the port is `443` if the protocol is `https`, or `80` if the protocol is `http`.