### PR TITLE
CFY-7350. Add role option to command

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -803,6 +803,13 @@ class Options(object):
             help=helptexts.SKIP_PLUGINS_VALIDATION
         )
 
+        self.user_role = click.option(
+            '-r',
+            '--role',
+            required=False,
+            help=helptexts.USER_ROLE,
+        )
+
         self.users = click.option(
             '-u',
             '--users',

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -205,6 +205,7 @@ SKIP_PLUGINS_VALIDATION = 'Determines whether to validate if the' \
 
 USER = 'Username of user to whom the permissions apply. ' \
        'This argument can be used multiple times'
+USER_ROLE = 'Role assigned to user in the context of the tenant.'
 PERMISSION = 'The permission applicable to a resource [viewer|owner] ' \
              '(default:viewer)'
 RESTORE_CERTIFICATES = 'Restore the certificates from the snapshot, using ' \

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -71,12 +71,13 @@ def create(tenant_name, logger, client):
 @tenants.command(name='add-user',
                  short_help='Add a user to a tenant [manager only]')
 @cfy.argument('username', callback=cfy.validate_name)
+@cfy.options.user_role
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()
 @cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
-def add_user(username, tenant_name, logger, client):
+def add_user(username, tenant_name, role, logger, client):
     """Add a user to a tenant
 
     `USERNAME` is the name of the user to add to the tenant
@@ -84,7 +85,7 @@ def add_user(username, tenant_name, logger, client):
     graceful_msg = 'User `{0}` is already associated with ' \
                    'tenant `{1}`'.format(username, tenant_name)
     with handle_client_error(409, graceful_msg, logger):
-        client.tenants.add_user(username, tenant_name)
+        client.tenants.add_user(username, tenant_name, role)
         logger.info('User `{0}` added successfully to tenant '
                     '`{1}`'.format(username, tenant_name))
 

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -82,12 +82,16 @@ def add_user(username, tenant_name, role, logger, client):
 
     `USERNAME` is the name of the user to add to the tenant
     """
-    graceful_msg = 'User `{0}` is already associated with ' \
-                   'tenant `{1}`'.format(username, tenant_name)
+    graceful_msg = (
+        'User `{0}` is already associated with tenant `{1}`'
+        .format(username, tenant_name)
+    )
     with handle_client_error(409, graceful_msg, logger):
         client.tenants.add_user(username, tenant_name, role)
-        logger.info('User `{0}` added successfully to tenant '
-                    '`{1}`'.format(username, tenant_name))
+        logger.info(
+            'User `{0}` added successfully to tenant `{1}`'
+            .format(username, tenant_name)
+        )
 
 
 @tenants.command(name='remove-user',


### PR DESCRIPTION
In this PR, the `-r/--role` flag is used to the `cfy tenants add-user` command, so that the role value can be set in the CLI.

Requires: cloudify-cosmo/cloudify-rest-client#194