### PR TITLE
CFY-7373. Add group to tenant with role

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -705,6 +705,13 @@ class Options(object):
             callback=validate_name
         )
 
+        self.group_role = click.option(
+            '-r',
+            '--role',
+            required=False,
+            help=helptexts.GROUP_ROLE,
+        )
+
         self.ldap_distinguished_name = click.option(
             '-l',
             '--ldap-distinguished-name',

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -178,6 +178,9 @@ ALL_TENANTS = 'Include resources from all tenants associated with the user. ' \
 GROUP = 'The name of the user group'
 GROUP_DN = 'The ldap group\'s distinguished name. This option is required ' \
            'when using ldap'
+GROUP_ROLE = (
+    'Role assigned to the users of group in the context of the tenant.'
+)
 
 SECURITY_ROLE = "A role to determine the user's permissions on the manager " \
                 "(default: default)"

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -129,12 +129,16 @@ def add_group(user_group_name, tenant_name, role, logger, client):
 
     `USER_GROUP_NAME` is the name of the user group to add to the tenant
     """
-    graceful_msg = 'User group `{0}` is already associated with ' \
-                   'tenant `{1}`'.format(user_group_name, tenant_name)
+    graceful_msg = (
+        'User group `{0}` is already associated with tenant `{1}`'
+        .format(user_group_name, tenant_name)
+    )
     with handle_client_error(409, graceful_msg, logger):
         client.tenants.add_group(user_group_name, tenant_name, role)
-        logger.info('User group `{0}` added successfully to tenant '
-                    '`{1}`'.format(user_group_name, tenant_name))
+        logger.info(
+            'User group `{0}` added successfully to tenant `{1}`'
+            .format(user_group_name, tenant_name)
+        )
 
 
 @tenants.command(name='remove-user-group',

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -118,12 +118,13 @@ def remove_user(username, tenant_name, logger, client):
 @tenants.command(name='add-user-group',
                  short_help='Add a user group to a tenant [manager only]')
 @cfy.argument('user-group-name', callback=cfy.validate_name)
+@cfy.options.group_role
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()
 @cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
-def add_group(user_group_name, tenant_name, logger, client):
+def add_group(user_group_name, tenant_name, role, logger, client):
     """Add a user group to a tenant
 
     `USER_GROUP_NAME` is the name of the user group to add to the tenant
@@ -131,7 +132,7 @@ def add_group(user_group_name, tenant_name, logger, client):
     graceful_msg = 'User group `{0}` is already associated with ' \
                    'tenant `{1}`'.format(user_group_name, tenant_name)
     with handle_client_error(409, graceful_msg, logger):
-        client.tenants.add_group(user_group_name, tenant_name)
+        client.tenants.add_group(user_group_name, tenant_name, role)
         logger.info('User group `{0}` added successfully to tenant '
                     '`{1}`'.format(user_group_name, tenant_name))
 


### PR DESCRIPTION
In this PR, the role option is added to the `cfy tenants add-user-group` command.