### PR TITLE
CFY-7373. Add tenants update-group method

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -705,13 +705,6 @@ class Options(object):
             callback=validate_name
         )
 
-        self.group_role = click.option(
-            '-r',
-            '--role',
-            required=False,
-            help=helptexts.GROUP_ROLE,
-        )
-
         self.ldap_distinguished_name = click.option(
             '-l',
             '--ldap-distinguished-name',
@@ -1069,6 +1062,15 @@ class Options(object):
             '--role',
             required=required,
             help=helptexts.USER_ROLE,
+        )
+
+    @staticmethod
+    def group_role(required=False):
+        return click.option(
+            '-r',
+            '--role',
+            required=required,
+            help=helptexts.GROUP_ROLE,
         )
 
 

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -142,7 +142,7 @@ def remove_user(username, tenant_name, logger, client):
 @tenants.command(name='add-user-group',
                  short_help='Add a user group to a tenant [manager only]')
 @cfy.argument('user-group-name', callback=cfy.validate_name)
-@cfy.options.group_role
+@cfy.options.group_role()
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -165,6 +165,30 @@ def add_group(user_group_name, tenant_name, role, logger, client):
         )
 
 
+@tenants.command(
+    name='update-group',
+    short_help='Update group-tenant relationship [manager only]')
+@cfy.argument('user-group-name', callback=cfy.validate_name)
+@cfy.options.group_role(required=True)
+@cfy.options.tenant_name(show_default_in_help=False)
+@cfy.options.verbose()
+@cfy.assert_manager_active()
+@cfy.pass_client(use_tenant_in_header=False)
+@cfy.pass_logger
+def update_group(user_group_name, tenant_name, role, logger, client):
+    """Update group-tenant relationship."""
+    not_found_msg = (
+        'User `{0}` is *not* currently associated to tenant `{1}`'
+        .format(user_group_name, tenant_name)
+    )
+    with handle_client_error(404, not_found_msg, logger):
+        client.tenants.update_group(user_group_name, tenant_name, role)
+        logger.info(
+            'Group `{0}` updated successfully in tenant `{1}`'
+            .format(user_group_name, tenant_name)
+        )
+
+
 @tenants.command(name='remove-user-group',
                  short_help='Remove a user group from a tenant [manager only]')
 @cfy.argument('user-group-name', callback=cfy.validate_name)


### PR DESCRIPTION
This method allows updating the group-tenant relationship.

Requires: cloudify-cosmo/cloudify-rest-client#197