### PR TITLE
CFY-7373. Refactor role option

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1066,11 +1066,13 @@ class Options(object):
 
     @staticmethod
     def user_tenant_role(required=False):
-        return Options.tenant_role(helptexts.USER_ROLE, required=required)
+        return Options.tenant_role(
+            helptexts.USER_TENANT_ROLE, required=required)
 
     @staticmethod
     def group_tenant_role(required=False):
-        return Options.tenant_role(helptexts.GROUP_ROLE, required=required)
+        return Options.tenant_role(
+            helptexts.GROUP_TENANT_ROLE, required=required)
 
 
 options = Options()

--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1065,12 +1065,12 @@ class Options(object):
         )
 
     @staticmethod
-    def user_role(required=False):
-        return Options.role(helptexts.USER_ROLE, required=required)
+    def user_tenant_role(required=False):
+        return Options.tenant_role(helptexts.USER_ROLE, required=required)
 
     @staticmethod
-    def group_role(required=False):
-        return Options.role(helptexts.GROUP_ROLE, required=required)
+    def group_tenant_role(required=False):
+        return Options.tenant_role(helptexts.GROUP_ROLE, required=required)
 
 
 options = Options()

--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1056,22 +1056,21 @@ class Options(object):
             type=click.Path(exists=True))
 
     @staticmethod
-    def user_role(required=False):
+    def tenant_role(help_text, required=False):
         return click.option(
             '-r',
             '--role',
             required=required,
-            help=helptexts.USER_ROLE,
+            help=help_text
         )
 
     @staticmethod
+    def user_role(required=False):
+        return Options.role(helptexts.USER_ROLE, required=required)
+
+    @staticmethod
     def group_role(required=False):
-        return click.option(
-            '-r',
-            '--role',
-            required=required,
-            help=helptexts.GROUP_ROLE,
-        )
+        return Options.role(helptexts.GROUP_ROLE, required=required)
 
 
 options = Options()

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -178,7 +178,7 @@ ALL_TENANTS = 'Include resources from all tenants associated with the user. ' \
 GROUP = 'The name of the user group'
 GROUP_DN = 'The ldap group\'s distinguished name. This option is required ' \
            'when using ldap'
-GROUP_ROLE = (
+GROUP_TENANT_ROLE = (
     'Role assigned to the users of group in the context of the tenant.'
 )
 
@@ -208,7 +208,7 @@ SKIP_PLUGINS_VALIDATION = 'Determines whether to validate if the' \
 
 USER = 'Username of user to whom the permissions apply. ' \
        'This argument can be used multiple times'
-USER_ROLE = 'Role assigned to user in the context of the tenant.'
+USER_TENANT_ROLE = 'Role assigned to user in the context of the tenant.'
 PERMISSION = 'The permission applicable to a resource [viewer|owner] ' \
              '(default:viewer)'
 RESTORE_CERTIFICATES = 'Restore the certificates from the snapshot, using ' \

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -71,7 +71,7 @@ def create(tenant_name, logger, client):
 @tenants.command(name='add-user',
                  short_help='Add a user to a tenant [manager only]')
 @cfy.argument('username', callback=cfy.validate_name)
-@cfy.options.user_role()
+@cfy.options.user_tenant_role()
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()
@@ -98,7 +98,7 @@ def add_user(username, tenant_name, role, logger, client):
     name='update-user',
     short_help='Update user-tenant relationship [manager only]')
 @cfy.argument('username', callback=cfy.validate_name)
-@cfy.options.user_role(required=True)
+@cfy.options.user_tenant_role(required=True)
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()
@@ -142,7 +142,7 @@ def remove_user(username, tenant_name, logger, client):
 @tenants.command(name='add-user-group',
                  short_help='Add a user group to a tenant [manager only]')
 @cfy.argument('user-group-name', callback=cfy.validate_name)
-@cfy.options.group_role()
+@cfy.options.group_tenant_role()
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()
@@ -169,7 +169,7 @@ def add_group(user_group_name, tenant_name, role, logger, client):
     name='update-group',
     short_help='Update group-tenant relationship [manager only]')
 @cfy.argument('user-group-name', callback=cfy.validate_name)
-@cfy.options.group_role(required=True)
+@cfy.options.group_tenant_role(required=True)
 @cfy.options.tenant_name(show_default_in_help=False)
 @cfy.options.verbose()
 @cfy.assert_manager_active()


### PR DESCRIPTION
In this PR, the role options for the `cfy tenants add-user/add-user-group` commands are refactored.