### PR TITLE
CFY-7373. Rename command from `update-group` to `update-user-group`

### DIFF
--- a/cloudify_cli/commands/agents.py
+++ b/cloudify_cli/commands/agents.py
@@ -48,7 +48,7 @@ def _is_deployment_installed(client, deployment_id):
 def _deployment_exists(client, deployment_id):
     try:
         client.deployments.get(deployment_id)
-    except:
+    except Exception:
         return False
     return True
 

--- a/cloudify_cli/commands/ssh.py
+++ b/cloudify_cli/commands/ssh.py
@@ -117,7 +117,7 @@ def _open_interactive_shell(host_string, command=''):
 def _verify_tmux_exists_on_manager(host_string):
     try:
         run_command_on_manager('which tmux', host_string=host_string)
-    except:
+    except Exception:
         raise CloudifyCliError(
             'tmux executable not found on manager {0}.\n'
             'Please verify that tmux is installed and in PATH before '
@@ -176,7 +176,7 @@ def _get_all_sessions(logger, host_string):
         output = run_command_on_manager(
             'tmux list-sessions',
             host_string=host_string)
-    except:
+    except Exception:
         return None
     return output
 

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -166,7 +166,7 @@ def add_group(user_group_name, tenant_name, role, logger, client):
 
 
 @tenants.command(
-    name='update-group',
+    name='update-user-group',
     short_help='Update group-tenant relationship [manager only]')
 @cfy.argument('user-group-name', callback=cfy.validate_name)
 @cfy.options.group_tenant_role(required=True)


### PR DESCRIPTION
This is to be consistent since the add/remove commands are named
`add-user-group` and `remove-user-group`.