### PR TITLE
CFY-7373. Update REST client command names

### DIFF
--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -158,7 +158,7 @@ def add_group(user_group_name, tenant_name, role, logger, client):
         .format(user_group_name, tenant_name)
     )
     with handle_client_error(409, graceful_msg, logger):
-        client.tenants.add_group(user_group_name, tenant_name, role)
+        client.tenants.add_user_group(user_group_name, tenant_name, role)
         logger.info(
             'User group `{0}` added successfully to tenant `{1}`'
             .format(user_group_name, tenant_name)
@@ -182,7 +182,7 @@ def update_group(user_group_name, tenant_name, role, logger, client):
         .format(user_group_name, tenant_name)
     )
     with handle_client_error(404, not_found_msg, logger):
-        client.tenants.update_group(user_group_name, tenant_name, role)
+        client.tenants.update_user_group(user_group_name, tenant_name, role)
         logger.info(
             'Group `{0}` updated successfully in tenant `{1}`'
             .format(user_group_name, tenant_name)
@@ -205,7 +205,7 @@ def remove_group(user_group_name, tenant_name, logger, client):
     graceful_msg = 'User group `{0}` is not associated with ' \
                    'tenant `{1}`'.format(user_group_name, tenant_name)
     with handle_client_error(404, graceful_msg, logger):
-        client.tenants.remove_group(user_group_name, tenant_name)
+        client.tenants.remove_user_group(user_group_name, tenant_name)
         logger.info('User group `{0}` removed successfully from tenant '
                     '`{1}`'.format(user_group_name, tenant_name))
 

--- a/cloudify_cli/commands/tenants.py
+++ b/cloudify_cli/commands/tenants.py
@@ -148,7 +148,7 @@ def remove_user(username, tenant_name, logger, client):
 @cfy.assert_manager_active()
 @cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
-def add_group(user_group_name, tenant_name, role, logger, client):
+def add_user_group(user_group_name, tenant_name, role, logger, client):
     """Add a user group to a tenant
 
     `USER_GROUP_NAME` is the name of the user group to add to the tenant
@@ -175,7 +175,7 @@ def add_group(user_group_name, tenant_name, role, logger, client):
 @cfy.assert_manager_active()
 @cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
-def update_group(user_group_name, tenant_name, role, logger, client):
+def update_user_group(user_group_name, tenant_name, role, logger, client):
     """Update group-tenant relationship."""
     not_found_msg = (
         'User `{0}` is *not* currently associated to tenant `{1}`'
@@ -197,7 +197,7 @@ def update_group(user_group_name, tenant_name, role, logger, client):
 @cfy.assert_manager_active()
 @cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
-def remove_group(user_group_name, tenant_name, logger, client):
+def remove_user_group(user_group_name, tenant_name, logger, client):
     """Remove a user group from a tenant
 
     `USER_GROUP_NAME` is the name of the user group to remove from the tenant


### PR DESCRIPTION
For consistency they are now named `add/remove/update_user_group`
instead of just `add/remove/update_group`

Requires: cloudify-cosmo/cloudify-rest-client#200