### PR TITLE
CFY-6680: upgrade to click==4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         ]
     },
     install_requires=[
-        'click==4.0',
+        'click==4.1',
         'wagon[venv]==0.6.1',
         'pyyaml==3.10',
         'paramiko==1.18.3',


### PR DESCRIPTION
The latest is 6.x, but I chose 4.1 (the latest in the 4.x family) in order to reduce the risk of backward compatibility issues.