### PR TITLE
CFY-7439 cfy profiles use: only switch, don't update existing profiles

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -29,7 +29,6 @@ from cloudify_rest_client.exceptions import MaintenanceModeActiveError
 from cloudify_rest_client.exceptions import MaintenanceModeActivatingError
 
 from .. import env
-from .. import constants
 from ..cli import helptexts
 from ..inputs import inputs_to_dict
 from ..utils import generate_random_string
@@ -622,12 +621,6 @@ class Options(object):
         )
 
         self.ssh_port = click.option(
-            '--ssh-port',
-            required=False,
-            default=constants.REMOTE_EXECUTION_PORT,
-            help=helptexts.SSH_PORT)
-
-        self.ssh_port_no_default = click.option(
             '--ssh-port',
             required=False,
             help=helptexts.SSH_PORT)

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -160,18 +160,10 @@ def _switch_profile(manager_ip, profile_name, logger, **kwargs):
     # because the way to update an existing profile is `cfy profiles set`
     provided_options = [key for key, value in kwargs.items() if value]
     if any(provided_options):
-        error = CloudifyCliError(
-            'Profile {0} already exists, but a new {1} was provided'
-            .format(profile_name, ', '.join(provided_options)))
-
-        error.possible_solutions = [
-            "Update profile {0} using `cfy profiles set`".format(
-                profile_name),
-            "Choose another profile name",
-            "Delete profile {0} using `cfy profiles delete {0}`".format(
-                profile_name),
-        ]
-        raise error
+        logger.warning('Profile {0} already exists. '
+                       'The passed in options are ignored: {1}. '
+                       'To update the profile, use `cfy profiles set`'
+                       .format(profile_name, ', '.join(provided_options)))
 
     env.set_active_profile(profile_name)
     logger.info('Using manager {0}'.format(profile_name))

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -141,6 +141,23 @@ def use(manager_ip,
         return
 
     if env.is_profile_exists(profile_name):
+        # if using an existing profile, it is an error to provide any --option,
+        # because the way to update an existing profile is `cfy profiles set`
+        provided_options = [key for key, value in kwargs.items() if value]
+        if any(provided_options):
+            error = CloudifyCliError(
+                'Profile {0} already exists, but a new {1} was provided'
+                .format(profile_name, ', '.join(provided_options)))
+
+            error.possible_solutions = [
+                "Update profile {0} using `cfy profiles set`".format(
+                    profile_name),
+                "Choose another profile name",
+                "Delete profile {0} using `cfy profiles delete {0}`".format(
+                    profile_name),
+            ]
+            raise error
+
         env.set_active_profile(profile_name)
         logger.info('Using manager {0}'.format(profile_name))
         return

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -354,7 +354,7 @@ def set_profile(profile_name,
 @cfy.options.manager_tenant
 @cfy.options.ssh_user
 @cfy.options.ssh_key
-@cfy.options.ssh_port_no_default
+@cfy.options.ssh_port
 @cfy.options.ssl_state
 @cfy.options.rest_certificate
 @cfy.options.skip_credentials_validation
@@ -682,8 +682,6 @@ def _set_profile_context(profile_name,
         profile.ssh_key = ssh_key
     if ssh_user:
         profile.ssh_user = ssh_user
-    if ssh_port:
-        profile.ssh_port = ssh_port
     if rest_port:
         profile.rest_port = rest_port
     if manager_username:
@@ -692,6 +690,7 @@ def _set_profile_context(profile_name,
         profile.manager_password = manager_password
     if manager_tenant:
         profile.manager_tenant = manager_tenant
+    profile.ssh_port = ssh_port or constants.REMOTE_EXECUTION_PORT
     profile.rest_protocol = rest_protocol
     profile.rest_certificate = rest_certificate
     profile.bootstrap_state = 'Complete'

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -141,32 +141,40 @@ def use(manager_ip,
         return
 
     if env.is_profile_exists(profile_name):
-        # if using an existing profile, it is an error to provide any --option,
-        # because the way to update an existing profile is `cfy profiles set`
-        provided_options = [key for key, value in kwargs.items() if value]
-        if any(provided_options):
-            error = CloudifyCliError(
-                'Profile {0} already exists, but a new {1} was provided'
-                .format(profile_name, ', '.join(provided_options)))
+        _switch_profile(
+            manager_ip=manager_ip,
+            profile_name=profile_name,
+            logger=logger,
+            **kwargs)
+    else:
+        _create_profile(
+            manager_ip=manager_ip,
+            profile_name=profile_name,
+            skip_credentials_validation=skip_credentials_validation,
+            logger=logger,
+            **kwargs)
 
-            error.possible_solutions = [
-                "Update profile {0} using `cfy profiles set`".format(
-                    profile_name),
-                "Choose another profile name",
-                "Delete profile {0} using `cfy profiles delete {0}`".format(
-                    profile_name),
-            ]
-            raise error
 
-        env.set_active_profile(profile_name)
-        logger.info('Using manager {0}'.format(profile_name))
-        return
+def _switch_profile(manager_ip, profile_name, logger, **kwargs):
+    # if using an existing profile, it is an error to provide any --option,
+    # because the way to update an existing profile is `cfy profiles set`
+    provided_options = [key for key, value in kwargs.items() if value]
+    if any(provided_options):
+        error = CloudifyCliError(
+            'Profile {0} already exists, but a new {1} was provided'
+            .format(profile_name, ', '.join(provided_options)))
 
-    _create_profile(manager_ip=manager_ip,
-                    profile_name=profile_name,
-                    skip_credentials_validation=skip_credentials_validation,
-                    logger=logger,
-                    **kwargs)
+        error.possible_solutions = [
+            "Update profile {0} using `cfy profiles set`".format(
+                profile_name),
+            "Choose another profile name",
+            "Delete profile {0} using `cfy profiles delete {0}`".format(
+                profile_name),
+        ]
+        raise error
+
+    env.set_active_profile(profile_name)
+    logger.info('Using manager {0}'.format(profile_name))
 
 
 def _create_profile(

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -148,6 +148,11 @@ def use(manager_ip,
         env.set_active_profile('local')
         return
 
+    if env.is_profile_exists(profile_name):
+        env.set_active_profile(profile_name)
+        logger.info('Using manager {0}'.format(profile_name))
+        return
+
     rest_protocol = constants.SECURED_REST_PROTOCOL if ssl else \
         constants.DEFAULT_REST_PROTOCOL
 
@@ -173,9 +178,7 @@ def use(manager_ip,
         skip_credentials_validation
     )
 
-    if not env.is_profile_exists(profile_name):
-        init.init_manager_profile(profile_name=profile_name)
-
+    init.init_manager_profile(profile_name=profile_name)
     env.set_active_profile(profile_name)
 
     logger.info('Using manager {0} with port {1}'.format(

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -120,18 +120,10 @@ def list(logger):
 @cfy.options.verbose()
 @cfy.pass_logger
 def use(manager_ip,
-        ssh_user,
-        ssh_key,
-        ssh_port,
-        manager_username,
-        manager_password,
-        manager_tenant,
         profile_name,
-        rest_port,
-        ssl,
-        rest_certificate,
         skip_credentials_validation,
-        logger):
+        logger,
+        **kwargs):
     """Control a specific manager
 
     `PROFILE_NAME` can be either a manager IP or `local`.
@@ -153,6 +145,27 @@ def use(manager_ip,
         logger.info('Using manager {0}'.format(profile_name))
         return
 
+    _create_profile(manager_ip=manager_ip,
+                    profile_name=profile_name,
+                    skip_credentials_validation=skip_credentials_validation,
+                    logger=logger,
+                    **kwargs)
+
+
+def _create_profile(
+        manager_ip,
+        profile_name,
+        ssh_user,
+        ssh_key,
+        ssh_port,
+        manager_username,
+        manager_password,
+        manager_tenant,
+        rest_port,
+        ssl,
+        rest_certificate,
+        skip_credentials_validation,
+        logger):
     rest_protocol = constants.SECURED_REST_PROTOCOL if ssl else \
         constants.DEFAULT_REST_PROTOCOL
 

--- a/cloudify_cli/tests/commands/test_profiles.py
+++ b/cloudify_cli/tests/commands/test_profiles.py
@@ -353,9 +353,9 @@ class ProfilesTest(CliCommandTest):
            return_value={})
     def test_use_cannot_update_profile(self, *_):
         self.use_manager()
-        self.invoke('profiles use 10.10.1.10 -p abc',
-                    err_str_segment='Profile 10.10.1.10 already exists, '
-                                    'but a new manager_password was provided')
+        outcome = self.invoke('profiles use 10.10.1.10 -p abc')
+        self.assertIn('The passed in options are ignored: manager_password',
+                      outcome.logs)
 
     @patch('cloudify_cli.commands.profiles._get_provider_context',
            return_value={})

--- a/cloudify_cli/tests/commands/test_profiles.py
+++ b/cloudify_cli/tests/commands/test_profiles.py
@@ -348,3 +348,18 @@ class ProfilesTest(CliCommandTest):
         added_profile = env.get_profile_context('5.6.7.8')
         self.assertEqual('1.2.3.4', added_profile.manager_ip)
         self.assertEqual('5.6.7.8', added_profile.profile_name)
+
+    @patch('cloudify_cli.commands.profiles._get_provider_context',
+           return_value={})
+    def test_use_cannot_update_profile(self, *_):
+        self.use_manager()
+        self.invoke('profiles use 10.10.1.10 -p abc',
+                    err_str_segment='Profile 10.10.1.10 already exists, '
+                                    'but a new manager_password was provided')
+
+    @patch('cloudify_cli.commands.profiles._get_provider_context',
+           return_value={})
+    def test_use_existing_only_switches(self, mock_get_context):
+        self.use_manager()
+        self.invoke('profiles use 10.10.1.10')
+        self.assertFalse(mock_get_context.called)


### PR DESCRIPTION
For already existing profiles, only switch to them, don't actually try
to get provider context, or update the profile.

currently, `cfy profiles use` has 3 modes of working:
  1. create a new profile
  2. switch profiles
  3. switch profiles AND update the existing profile, 
      eg `cfy profiles use existing.profile.ip --password updated_password`

This change gets rid of 3, so it is an error to pass any flags (like `--password`)
when using `cfy profiles use` with an already existing profile.