### PR TITLE
CFY-7439 Don't update provider context in teardown

### DIFF
--- a/cloudify_cli/commands/teardown.py
+++ b/cloudify_cli/commands/teardown.py
@@ -17,7 +17,6 @@
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 from .. import env
-from .profiles import use
 from .. import exceptions
 from ..cli import cfy, helptexts
 from ..bootstrap import bootstrap as bs
@@ -67,27 +66,8 @@ def teardown(ctx, force, ignore_deployments):
         # deployments, unless the user explicitly specified it.
         _validate_deployments(ignore_deployments, manager_ip)
 
-        # update local provider context since the server ip might have
-        # changed in case it has gone through a recovery process.
-        _update_local_provider_context(ctx, manager_ip)
-
         # execute teardown
         _do_teardown()
-
-
-@cfy.pass_logger
-def _update_local_provider_context(ctx, manager_ip, logger):
-    try:
-        ctx.invoke(
-            use,
-            manager_ip=manager_ip,
-            rest_port=env.profile.rest_port,
-        )
-    except BaseException as e:
-        logger.warning('Failed to retrieve provider context: {0}. This '
-                       'may cause a leaking manager '
-                       'in case it has gone through a '
-                       'recovery process'.format(str(e)))
 
 
 def _get_number_of_deployments(manager_ip):


### PR DESCRIPTION
This was related to the recovery process, which isn't supported
anymore.