### PR TITLE
CFY-7332 Add a command to `profiles set` for a specific cluster node

### DIFF
--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -387,7 +387,7 @@ def set_cmd(profile_name,
 @profiles.command(
     name='set-cluster',
     short_help='Set connection options for a cluster node')
-@cfy.options.cluster_node_name
+@cfy.argument('cluster-node-name')
 @cfy.options.ssh_user
 @cfy.options.ssh_key
 @cfy.options.ssh_port

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -398,6 +398,10 @@ def set_cluster(cluster_node_name,
                 ssh_port,
                 rest_certificate,
                 logger):
+    """Set connection options for a cluster node.
+
+    `CLUSTER_NODE_NAME` is the name of the cluster node to set options for.
+    """
     if not env.profile.cluster:
         err = CloudifyCliError('The current profile is not a cluster profile!')
         err.possible_solutions = [

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -392,6 +392,7 @@ def set_cmd(profile_name,
 @cfy.options.ssh_key
 @cfy.options.ssh_port
 @cfy.options.rest_certificate
+@cfy.pass_logger
 def set_cluster(cluster_node_name,
                 ssh_user,
                 ssh_key,

--- a/cloudify_cli/tests/commands/test_profiles.py
+++ b/cloudify_cli/tests/commands/test_profiles.py
@@ -363,3 +363,20 @@ class ProfilesTest(CliCommandTest):
         self.use_manager()
         self.invoke('profiles use 10.10.1.10')
         self.assertFalse(mock_get_context.called)
+
+    @patch('cloudify_cli.commands.profiles._get_provider_context',
+           return_value={})
+    def test_cluster_set_changes_cert(self, mock_get_context):
+        self.use_manager()
+        env.profile.cluster = [{'name': 'first'}]
+        self.invoke('profiles set-cluster first --rest-certificate CERT_PATH')
+        self.assertIn('cert', env.profile.cluster[0])
+        self.assertEqual(env.profile.cluster[0]['cert'], 'CERT_PATH')
+
+    @patch('cloudify_cli.commands.profiles._get_provider_context',
+           return_value={})
+    def test_cluster_set_nonexistent_node(self, mock_get_context):
+        self.use_manager()
+        env.profile.cluster = [{'name': 'first'}]
+        self.invoke('profiles set-cluster second --rest-certificate CERT_PATH',
+                    err_str_segment='second not found')


### PR DESCRIPTION
Similar to how `cfy profiles set` allows setting things like the
REST cert and ssh params for a profile, `cfy profiles set-cluster`
allows setting those for a specific node in a cluster.

This means we can use the cli to set a different cert for every
cluster node.