### PR TITLE
CFY-7562. Secret create update_if_exists

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -816,6 +816,13 @@ class Options(object):
             required=False,
             help=helptexts.SECRET_FILE)
 
+        self.secret_upsert = click.option(
+            '-u',
+            '--upsert',
+            is_flag=True,
+            help=helptexts.SECRET_UPSERT,
+        )
+
         # same as --inputs, name changed for consistency
         self.cluster_node_options = click.option(
             '-o',

--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -816,11 +816,11 @@ class Options(object):
             required=False,
             help=helptexts.SECRET_FILE)
 
-        self.secret_upsert = click.option(
+        self.secret_update_if_exists = click.option(
             '-u',
-            '--upsert',
+            '--update-if-exists',
             is_flag=True,
-            help=helptexts.SECRET_UPSERT,
+            help=helptexts.SECRET_UPDATE_IF_EXISTS,
         )
 
         # same as --inputs, name changed for consistency

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -236,6 +236,7 @@ PROFILE_NAME = 'Name of the profile to use'
 SECRET_VALUE = "The secret's value to be set"
 SECRET_STRING = "The string to use as the secret's value"
 SECRET_FILE = "The secret's file to use its content as value to be set"
+SECRET_UPSERT = 'Update secret with new value if it already exists'
 CLUSTER_NODE_OPTIONS = 'Additional options for the cluster node '\
                        'configuration {0}'.format(INPUTS_PARAMS_USAGE)
 

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -236,7 +236,7 @@ PROFILE_NAME = 'Name of the profile to use'
 SECRET_VALUE = "The secret's value to be set"
 SECRET_STRING = "The string to use as the secret's value"
 SECRET_FILE = "The secret's file to use its content as value to be set"
-SECRET_UPSERT = 'Update secret with new value if it already exists'
+SECRET_UPDATE_IF_EXISTS = 'Update secret value if secret key already exists'
 CLUSTER_NODE_OPTIONS = 'Additional options for the cluster node '\
                        'configuration {0}'.format(INPUTS_PARAMS_USAGE)
 

--- a/cloudify_cli/commands/secrets.py
+++ b/cloudify_cli/commands/secrets.py
@@ -42,12 +42,12 @@ def secrets():
 @cfy.argument('key', callback=cfy.validate_name)
 @cfy.options.secret_string
 @cfy.options.secret_file
-@cfy.options.secret_upsert
+@cfy.options.secret_update_if_exists
 @cfy.options.verbose()
 @cfy.assert_manager_active()
 @cfy.pass_client(use_tenant_in_header=True)
 @cfy.pass_logger
-def create(key, secret_string, secret_file, upsert, logger, client):
+def create(key, secret_string, secret_file, update_if_exists, logger, client):
     """Create a new secret (key-value pair)
 
     `KEY` is the new secret's key
@@ -71,7 +71,7 @@ def create(key, secret_string, secret_file, upsert, logger, client):
                    'tenant or as a global secret'.format(key)
 
     with handle_client_error(409, graceful_msg, logger):
-        client.secrets.create(key, secret_string, upsert)
+        client.secrets.create(key, secret_string, update_if_exists)
         logger.info('Secret `{0}` created'.format(key))
 
 

--- a/cloudify_cli/commands/secrets.py
+++ b/cloudify_cli/commands/secrets.py
@@ -42,11 +42,12 @@ def secrets():
 @cfy.argument('key', callback=cfy.validate_name)
 @cfy.options.secret_string
 @cfy.options.secret_file
+@cfy.options.secret_upsert
 @cfy.options.verbose()
 @cfy.assert_manager_active()
 @cfy.pass_client(use_tenant_in_header=True)
 @cfy.pass_logger
-def create(key, secret_string, secret_file, logger, client):
+def create(key, secret_string, secret_file, upsert, logger, client):
     """Create a new secret (key-value pair)
 
     `KEY` is the new secret's key
@@ -70,7 +71,7 @@ def create(key, secret_string, secret_file, logger, client):
                    'tenant or as a global secret'.format(key)
 
     with handle_client_error(409, graceful_msg, logger):
-        client.secrets.create(key, secret_string)
+        client.secrets.create(key, secret_string, upsert)
         logger.info('Secret `{0}` created'.format(key))
 
 


### PR DESCRIPTION
In this PR, the create secret command is updated to handle the upsert flag that is now supported by the REST API.

Requires: cloudify-cosmo/cloudify-rest-client#206