### PR TITLE
CFY-7801 Error message for using `plugin:` with `blueprint validate`

### DIFF
--- a/cloudify_cli/tests/commands/test_blueprints.py
+++ b/cloudify_cli/tests/commands/test_blueprints.py
@@ -170,6 +170,12 @@ class BlueprintsTest(CliCommandTest):
             .format(BLUEPRINTS_DIR),
             err_str_segment='Failed to validate blueprint')
 
+    def test_validate_plugin_repository(self):
+        self.invoke(
+            'cfy blueprints validate {0}/bad_blueprint/plugin_repo.yaml'
+            .format(BLUEPRINTS_DIR),
+            err_str_segment='plugin repository')
+
     def test_blueprint_inputs(self):
 
         blueprint_id = 'a-blueprint-id'

--- a/cloudify_cli/tests/resources/blueprints/bad_blueprint/plugin_repo.yaml
+++ b/cloudify_cli/tests/resources/blueprints/bad_blueprint/plugin_repo.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+description: >
+    This plugin tries to use a plugin repository URL (`plugin:...`)
+    with a local `cfy blueprints validate`
+
+imports:
+  - http://www.getcloudify.org/spec/cloudify/4.3.dev1/types.yaml
+  - plugin:cloudify-openstack-plugin
+
+node_templates:
+  x:
+    type: cloudify.nodes.Root


### PR DESCRIPTION
This blueprint can't be validated locally, instead it must be
uploaded to a manager.

Example:
```
Validating blueprint: bp.yaml
Error fetching plugin yaml: 'plugin:cloudify-openstack-plugin'
Blueprints using plugin repository imports can not be validated locally.
Possible solutions:
  - Upload the blueprint to a Cloudify Manager
  - Use an explicit URL to the plugin YAML file instead of a plugin repository `plugin:` import.

```