### PR TITLE
CFY-7709 `cluster nodes list` also updates profile

### DIFF
--- a/cloudify_cli/commands/cluster.py
+++ b/cloudify_cli/commands/cluster.py
@@ -338,14 +338,13 @@ def _prepare_node(node):
 def list_nodes(client, logger):
     """Display a table with basic information about the nodes in the cluster
     """
-
     response = client.cluster.nodes.list()
     for node in response:
         _prepare_node(node)
     print_data(CLUSTER_COLUMNS, response, 'HA Cluster nodes',
                defaults=CLUSTER_COLUMNS_DEFAULTS,
                labels={'services': 'cloudify services'})
-    _update_profile_cluster_settings(env.profile, nodes, logger=logger)
+    _update_profile_cluster_settings(env.profile, response, logger=logger)
 
 
 @nodes.command(name='get',

--- a/cloudify_cli/commands/cluster.py
+++ b/cloudify_cli/commands/cluster.py
@@ -241,18 +241,19 @@ def update_profile(client, logger):
     will be contacted in case of a cluster master failure.
     """
     logger.info('Fetching the cluster nodes list...')
-    _update_profile_cluster_settings(env.profile, client, logger=logger)
+    nodes = client.cluster.nodes.list()
+    _update_profile_cluster_settings(env.profile, nodes, logger=logger)
     logger.info('Profile is up to date with {0} nodes'
                 .format(len(env.profile.cluster)))
 
 
-def _update_profile_cluster_settings(profile, client, logger=None):
-    nodes = client.cluster.nodes.list()
+def _update_profile_cluster_settings(profile, nodes, logger=None):
     stored_nodes = {node['manager_ip'] for node in env.profile.cluster}
     for node in nodes:
         if node.host_ip not in stored_nodes:
             if logger:
-                logger.info('Adding cluster node: {0}'.format(node.host_ip))
+                logger.info('Adding cluster node {0} to local profile'
+                            .format(node.host_ip))
             env.profile.cluster.append({
                 # currently only the host IP is received; all other parameters
                 # will be defaulted to the ones from the last used manager
@@ -344,6 +345,7 @@ def list_nodes(client, logger):
     print_data(CLUSTER_COLUMNS, response, 'HA Cluster nodes',
                defaults=CLUSTER_COLUMNS_DEFAULTS,
                labels={'services': 'cloudify services'})
+    _update_profile_cluster_settings(env.profile, nodes, logger=logger)
 
 
 @nodes.command(name='get',

--- a/cloudify_cli/tests/commands/test_cluster.py
+++ b/cloudify_cli/tests/commands/test_cluster.py
@@ -306,8 +306,8 @@ class UpdateProfileTest(CliCommandTest):
         self.client.cluster.join = mock.Mock()
 
         outcome = self.invoke('cfy cluster update-profile')
-        self.assertIn('Adding cluster node: 1.2.3.4', outcome.logs)
-        self.assertIn('Adding cluster node: 5.6.7.8', outcome.logs)
+        self.assertIn('Adding cluster node 1.2.3.4', outcome.logs)
+        self.assertIn('Adding cluster node 5.6.7.8', outcome.logs)
 
         self.assertEqual(env.profile.cluster,
                          [


### PR DESCRIPTION
Since we already download the nodes list in `cluster nodes list`,
we might as well also update the local profile (which required
a `cfy cluster update-profile` before).