### PR TITLE
CFY-7904 Remove HTTP/S read timeout from the cluster client

### DIFF
--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -522,7 +522,7 @@ CLUSTER_NODE_ATTRS = ['manager_ip', 'rest_port', 'rest_protocol', 'ssh_port',
 
 
 class ClusterHTTPClient(HTTPClient):
-    default_timeout_sec = 5
+    default_timeout_sec = (5, None)
 
     def __init__(self, *args, **kwargs):
         profile = kwargs.pop('profile')


### PR DESCRIPTION
Setting the timeout value to `(5, None)` means that we're waiting 5 seconds for the connection to be established (which should be plenty enough), but we aren't setting a _read_ timeout (the actual time it takes for the operation to be performed on the manager).