### PR TITLE
build script: update nss

### DIFF
--- a/packaging/linux/provision.sh
+++ b/packaging/linux/provision.sh
@@ -51,17 +51,18 @@ function prepare_linux () {
     if  which yum >> /dev/null; then
         sudo yum install -y http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
         sudo yum install -y git fakeroot python-devel rpm-build
+        sudo yum update -y nss
         gpg=gpg2
     else
         sudo apt-get install -y git curl fakeroot python-dev
         gpg=gpg
     fi
-    
+
     $gpg --keyserver hkp://keys.gnupg.net --recv-keys \
         409B6B1796C275462A1703113804BB82D39DC0E3 \
         7D2BAF1CF37B13E2069D6956105BD0E739499BDB
     curl -sSL https://get.rvm.io | bash -s stable
-    
+
     if  which yum >> /dev/null; then
         source /etc/profile.d/rvm.sh
     else


### PR DESCRIPTION
On centos, nss (the ssl/tls lib used by curl & git) must be a recent
enough version to support tlsv1.2, so that we can connect to github.
As of 23.02.2018, github has dropped support for old tls versions
( https://github.com/blog/2507-weak-cryptographic-standards-removed )