### PR TITLE
CY-344 Don't pass the `stop_old_agent` param if it's false

### DIFF
--- a/cloudify_cli/commands/agents.py
+++ b/cloudify_cli/commands/agents.py
@@ -89,7 +89,11 @@ def install(deployment_id,
     """
     if manager_certificate:
         manager_certificate = _validate_certificate_file(manager_certificate)
-    params = {'stop_old_agent': stop_old_agent}
+    params = {}
+    # We only want to pass this arg if it's true, because of backwards
+    # compatibility with blueprints that don't support it
+    if stop_old_agent:
+        params['stop_old_agent'] = stop_old_agent
     if manager_ip or manager_certificate:
         params['manager_ip'] = manager_ip
         params['manager_certificate'] = manager_certificate


### PR DESCRIPTION
Because otherwise, it would be checked against old `install_new_agent`
workflow params (from old types.yaml files) and the execution will fail