### PR TITLE
Added --ignore-plugin-installation-failure flag to 'cfy snapshot rest…

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -920,6 +920,13 @@ class Options(object):
             help=helptexts.STOP_OLD_AGENT
         )
 
+        self.ignore_plugin_installation_failure = click.option(
+            '--ignore-plugin-installation-failure',
+            is_flag=True,
+            default=False,
+            help=helptexts.IGNORE_PLUGIN_INSTALLATION_FAILURE
+        )
+
     @staticmethod
     def secret_file():
         return click.option(

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -282,3 +282,7 @@ STOP_OLD_AGENT = 'If set, after installing the new agent the old agent ' \
                  '(that is connected to the old Cloudify Manager) will be ' \
                  'stopped. *IMPORTANT* if the deployment has monitoring ' \
                  'with auto-healing configured, you need to disable it first'
+IGNORE_PLUGIN_INSTALLATION_FAILURE = 'if set, plugin installation errors ' \
+                                     'during snapshot restore will only be ' \
+                                     'logged as warnings, and will not fail' \
+                                     ' the snapshot restore workflow'

--- a/cloudify_cli/commands/snapshots.py
+++ b/cloudify_cli/commands/snapshots.py
@@ -39,6 +39,7 @@ def snapshots():
 @cfy.options.force(help=helptexts.FORCE_RESTORE_ON_DIRTY_MANAGER)
 @cfy.options.restore_certificates
 @cfy.options.no_reboot
+@cfy.options.ignore_plugin_installation_failure
 @cfy.options.verbose()
 @cfy.pass_client(use_tenant_in_header=False)
 @cfy.pass_logger
@@ -47,6 +48,7 @@ def restore(snapshot_id,
             force,
             restore_certificates,
             no_reboot,
+            ignore_plugin_installation_failure,
             logger,
             client):
     """Restore a manager to its previous state
@@ -60,7 +62,8 @@ def restore(snapshot_id,
         recreate_deployments_envs,
         force,
         restore_certificates,
-        no_reboot
+        no_reboot,
+        ignore_plugin_installation_failure
     )
     logger.info("Started workflow execution. The execution's id is {0}".format(
         execution.id))

--- a/cloudify_cli/tests/commands/test_snapshots.py
+++ b/cloudify_cli/tests/commands/test_snapshots.py
@@ -39,6 +39,8 @@ class SnapshotsTest(CliCommandTest):
         self.invoke('cfy snapshots restore a-snapshot-id')
         self.invoke('cfy snapshots restore a-snapshot-id'
                     '--without-deployments-envs')
+        self.invoke('cfy snapshots restore a-snapshot-id'
+                    '--ignore-plugin-installation-failure')
 
     def test_snapshots_download(self):
         self.client.snapshots.download = MagicMock(return_value='some_file')


### PR DESCRIPTION
…ore' command, will ignore any plugins failing to install during a snapshot restore operation.