### PR TITLE
Executions should include quotes

### DIFF
--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -25,7 +25,7 @@ VERSION = (
 INPUTS_PARAMS_USAGE = (
     '(Can be provided as wildcard based paths '
     '(*.yaml, /my_inputs/, etc..) to YAML files, a JSON string or as '
-    'key1=value1;key2=value2). This argument can be used multiple times'
+    '\'key1=value1;key2=value2\'). This argument can be used multiple times'
 )
 WORKFLOW_TO_EXECUTE = "The workflow to execute [default: {0}]"
 


### PR DESCRIPTION
Executions params should be between quotes otherwise the semicolon is handled by bash as the end of the command