### PR TITLE
Allow agent filter options to be both multiple and comma-separated

### DIFF
--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -287,9 +287,16 @@ IGNORE_PLUGIN_FAILURE = 'If set, plugin installation errors during snapshot ' \
                         'restore will only be logged as warnings, and will ' \
                         'not fail the snapshot restore workflow'
 QUEUE_SNAPSHOTS = 'If set, blocked snapshot-creation-workflows will be ' \
-                   'queued and automatically run when possible'
+                  'queued and automatically run when possible'
 QUEUE_EXECUTIONS = 'If set, blocked executions will be queued and ' \
                    'automatically run when possible'
-AGENT_NODE_INSTANCE_ID = 'The node instance id to be used for filtering'
-AGENT_NODE_ID = 'The node id to filter to be used for filtering'
-AGENT_INSTALL_METHOD = 'Only show agents installed with this install_method'
+
+_MULTIPLE_TIMES_FRAGMENT = ' (can be passed multiple times, ' \
+                           'or comma-separated)'
+AGENT_NODE_INSTANCE_ID = 'The node instance id to be used for filtering ' \
+                         + _MULTIPLE_TIMES_FRAGMENT
+AGENT_NODE_ID = 'The node id to filter to be used for filtering' \
+                + _MULTIPLE_TIMES_FRAGMENT
+AGENT_INSTALL_METHOD = 'Only show agents installed with this install_method' \
+                       + _MULTIPLE_TIMES_FRAGMENT
+AGENT_DEPLOYMENT_ID = DEPLOYMENT_ID + _MULTIPLE_TIMES_FRAGMENT

--- a/cloudify_cli/tests/commands/test_options.py
+++ b/cloudify_cli/tests/commands/test_options.py
@@ -7,10 +7,10 @@ from .test_base import CliCommandTest
 
 
 class OptionsTest(CliCommandTest):
-
     def setUp(self):
         super(OptionsTest, self).setUp()
         self.use_manager()
+        self.client.agents.list = MagicMock(return_value=MockListResponse())
 
     def test_json_command_sets(self):
         self.client.blueprints.list = MagicMock(
@@ -25,3 +25,27 @@ class OptionsTest(CliCommandTest):
         )
         self.invoke('cfy blueprints list --format json')
         self.assertTrue(get_global_json_output())
+
+    def test_agent_filters_multiple(self):
+        self.invoke('agents list --node-id a --node-id b')
+        self.client.agents.list.assert_called_with(
+            deployment_id=[],
+            install_methods=[],
+            node_ids=['a', 'b'],
+            node_instance_ids=[])
+
+    def test_agent_filters_commaseparated(self):
+        self.invoke('agents list --node-id a,b')
+        self.client.agents.list.assert_called_with(
+            deployment_id=[],
+            install_methods=[],
+            node_ids=['a', 'b'],
+            node_instance_ids=[])
+
+    def test_agent_filters_commaseparated_multiple(self):
+        self.invoke('agents list --node-id a,b --node-id c')
+        self.client.agents.list.assert_called_with(
+            deployment_id=[],
+            install_methods=[],
+            node_ids=['a', 'b', 'c'],
+            node_instance_ids=[])


### PR DESCRIPTION
Allows `cfy agents list --node-id a --node-id b,c,d` to result in
node_ids=['a', 'b', 'c', 'd']