### PR TITLE
CY-873 cfy profiles show: show cluster nodes

### DIFF
--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -71,7 +71,24 @@ def show(logger):
         return
 
     active_profile = _get_profile(env.get_active_profile())
-    print_single(PROFILE_COLUMNS, active_profile, 'Active profile:')
+    if active_profile.get('cluster'):
+        common_attributes = {k: active_profile.get(k) for k in PROFILE_COLUMNS}
+        nodes = []
+        for node in active_profile['cluster']:
+            # merge the common attrs with node data, but rename node's name
+            # attribute to cluster_node, because the attribute 'name' is
+            # reserved for the profile name
+            node_data = dict(node)
+            node_data['cluster_node_name'] = node_data.pop('name')
+            nodes.append(dict(common_attributes, **node_data))
+
+        columns = PROFILE_COLUMNS[:1] + ['cluster_node_name'] \
+            + PROFILE_COLUMNS[1:]
+        print_data(columns, nodes, 'Cluster nodes in profile {0}:'
+                   .format(active_profile['name']),
+                   labels={'cluster_node_name': 'cluster node name'})
+    else:
+        print_single(PROFILE_COLUMNS, active_profile, 'Active profile:')
 
 
 @profiles.command(name='list',

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -39,6 +39,8 @@ EXPORTED_SSH_KEYS_DIR = os.path.join(env.PROFILES_DIR, EXPORTED_KEYS_DIRNAME)
 PROFILE_COLUMNS = ['name', 'manager_ip', 'manager_username', 'manager_tenant',
                    'ssh_user', 'ssh_key_path', 'ssh_port', 'kerberos_env',
                    'rest_port', 'rest_protocol', 'rest_certificate']
+CLUSTER_PROFILE_COLUMNS = ['profile_name', 'cluster_node_name'] \
+    + PROFILE_COLUMNS[1:]
 
 
 @cfy.group(name='profiles')
@@ -57,6 +59,24 @@ def profiles():
         init.init_local_profile()
 
 
+def _format_cluster_profile(profile):
+    """Format the list of cluster nodes for display
+
+    In `cfy cluster show`, we show the profile details of every stored
+    cluster node.
+    """
+    common_attributes = {k: profile.get(k) for k in PROFILE_COLUMNS}
+    nodes = []
+    for node in profile['cluster']:
+        # merge the common attrs with node data, but rename node's name
+        # attribute to cluster_node, because the attribute 'name' is
+        # reserved for the profile name
+        node_data = dict(node)
+        node_data['cluster_node_name'] = node_data.pop('name')
+        nodes.append(dict(common_attributes, **node_data))
+    return nodes
+
+
 @profiles.command(name='show-current',
                   short_help='Retrieve current profile information')
 @cfy.options.common_options
@@ -72,21 +92,15 @@ def show(logger):
 
     active_profile = _get_profile(env.get_active_profile())
     if active_profile.get('cluster'):
-        common_attributes = {k: active_profile.get(k) for k in PROFILE_COLUMNS}
-        nodes = []
-        for node in active_profile['cluster']:
-            # merge the common attrs with node data, but rename node's name
-            # attribute to cluster_node, because the attribute 'name' is
-            # reserved for the profile name
-            node_data = dict(node)
-            node_data['cluster_node_name'] = node_data.pop('name')
-            nodes.append(dict(common_attributes, **node_data))
 
         columns = PROFILE_COLUMNS[:1] + ['cluster_node_name'] \
             + PROFILE_COLUMNS[1:]
-        print_data(columns, nodes, 'Cluster nodes in profile {0}:'
+        print_data(columns, _format_cluster_profile(active_profile),
+                   'Cluster nodes in profile {0}:'
                    .format(active_profile['name']),
-                   labels={'cluster_node_name': 'cluster node name'})
+                   labels={
+                   'profile_name': 'name',
+                   'cluster_node_name': 'cluster node name'})
     else:
         print_single(PROFILE_COLUMNS, active_profile, 'Active profile:')
 


### PR DESCRIPTION
Instead of showing just the profile data which contains a single
manager_ip, if the current profile is a cluster profile, show
all stored nodes