### PR TITLE
CY-642: changing the namespace delimiter

### DIFF
--- a/cloudify_cli/tests/resources/blueprints/bad_blueprint/blueprint_catalog.yaml
+++ b/cloudify_cli/tests/resources/blueprints/bad_blueprint/blueprint_catalog.yaml
@@ -6,7 +6,7 @@ description: >
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/4.5.5.dev1/types.yaml
-  - ns->blueprint:test
+  - ns--blueprint:test
 
 node_templates:
   x:


### PR DESCRIPTION
- Due to the naming limitation of the host agent name