### PR TITLE
Agents install: allow_custom_parameters=True

### DIFF
--- a/cloudify_cli/commands/agents.py
+++ b/cloudify_cli/commands/agents.py
@@ -240,7 +240,8 @@ def run_worker(
         timeout = 900
         try:
             execution = client.executions.start(
-                dep_id, workflow_id, parameters)
+                dep_id, workflow_id, parameters,
+                allow_custom_parameters=True)
             execution = wait_for_execution(
                 client,
                 execution,

--- a/cloudify_cli/tests/test_env.py
+++ b/cloudify_cli/tests/test_env.py
@@ -657,22 +657,22 @@ class ExecutionEventsFetcherTest(CliCommandTest):
         self.assertEqual(0, remaining_events_count)
 
     def test_fetch_and_process_events_explicit_several_batches(self):
-            total_events_count = 0
-            self.events = self._generate_events(9)
-            batch_size = 2
-            events_fetcher = ExecutionEventsFetcher(self.client,
-                                                    'execution_id',
-                                                    batch_size=batch_size)
-            for i in range(0, 4):
-                events_batch_count, _ = \
-                    events_fetcher.fetch_and_process_events_batch()
-                self.assertEqual(events_batch_count, batch_size)
-                total_events_count += events_batch_count
-            remaining_events_count, _ = \
+        total_events_count = 0
+        self.events = self._generate_events(9)
+        batch_size = 2
+        events_fetcher = ExecutionEventsFetcher(self.client,
+                                                'execution_id',
+                                                batch_size=batch_size)
+        for i in range(0, 4):
+            events_batch_count, _ = \
                 events_fetcher.fetch_and_process_events_batch()
-            self.assertEqual(remaining_events_count, 1)
-            total_events_count += remaining_events_count
-            self.assertEqual(len(self.events), total_events_count)
+            self.assertEqual(events_batch_count, batch_size)
+            total_events_count += events_batch_count
+        remaining_events_count, _ = \
+            events_fetcher.fetch_and_process_events_batch()
+        self.assertEqual(remaining_events_count, 1)
+        total_events_count += remaining_events_count
+        self.assertEqual(len(self.events), total_events_count)
 
     def test_fetch_events_explicit_single_batch(self):
         self.events = self._generate_events(10)


### PR DESCRIPTION
This allows using --stop-old-agents on deployments using an old
types.yaml