### PR TITLE
Execution id parameter: allow workflow id

### DIFF
--- a/cloudify_cli/commands/events.py
+++ b/cloudify_cli/commands/events.py
@@ -37,7 +37,7 @@ def events():
 
 @events.command(name='list',
                 short_help='List deployments events [manager only]')
-@cfy.argument('execution-id', required=False)
+@cfy.options.execution_id_argument(required=False)
 @cfy.options.execution_id(required=False, dest='execution_id_opt')
 @cfy.options.include_logs
 @cfy.options.json_output
@@ -58,6 +58,12 @@ def list(execution_id,
          pagination_size,
          client,
          logger):
+    """Show events of the given execution.
+
+    `EXECUTION_ID` is the execution to get events for.
+    Execution ID can also be the workflow name to use the most recent
+    execution of that workflow.
+    """
     if execution_id and execution_id_opt:
         raise click.UsageError(
             "Execution ID provided both as a positional "

--- a/cloudify_cli/commands/executions.py
+++ b/cloudify_cli/commands/executions.py
@@ -64,7 +64,7 @@ def executions():
 
 @cfy.command(name='get',
              short_help='Retrieve execution information [manager only]')
-@cfy.argument('execution-id')
+@cfy.options.execution_id_argument()
 @cfy.options.common_options
 @cfy.options.tenant_name(required=False, resource_name_for_help='execution')
 @cfy.assert_manager_active()
@@ -74,6 +74,8 @@ def manager_get(execution_id, logger, client, tenant_name):
     """Retrieve information for a specific execution
 
     `EXECUTION_ID` is the execution to get information on.
+    Execution ID can also be the workflow name to use the most recent
+    execution of that workflow.
     """
     utils.explicit_tenant_name_message(tenant_name, logger)
     try:
@@ -313,7 +315,7 @@ def manager_start(workflow_id,
 
 @cfy.command(name='cancel',
              short_help='Cancel a workflow execution [manager only]')
-@cfy.argument('execution-id')
+@cfy.options.execution_id_argument()
 @cfy.options.common_options
 @cfy.options.force(help=helptexts.FORCE_CANCEL_EXECUTION)
 @cfy.options.kill()
@@ -325,6 +327,8 @@ def manager_cancel(execution_id, force, kill, logger, client, tenant_name):
     """Cancel a workflow's execution
 
     `EXECUTION_ID` is the ID of the execution to cancel.
+    Execution ID can also be the workflow name to use the most recent
+    execution of that workflow.
     """
     utils.explicit_tenant_name_message(tenant_name, logger)
     if kill:
@@ -343,7 +347,7 @@ def manager_cancel(execution_id, force, kill, logger, client, tenant_name):
 
 @cfy.command(name='resume',
              short_help='Resume a workflow execution [manager only]')
-@cfy.argument('execution-id')
+@cfy.options.execution_id_argument()
 @cfy.options.common_options
 @cfy.options.reset_operations
 @cfy.options.tenant_name(required=False, resource_name_for_help='execution')
@@ -355,6 +359,9 @@ def manager_resume(execution_id, reset_operations, logger, client,
     """Resume the execution of a workflow in a failed or cancelled state.
 
     `EXECUTION_ID` is the ID of the execution to resume.
+    Execution ID can also be the workflow name to use the most recent
+    execution of that workflow.
+
     The workflow will run again, restoring the tasks graph from the storage,
     and retrying failed tasks when necessary.
     If reset-operations is passed, tasks that were started but didn't fail

--- a/cloudify_cli/tests/commands/test_events.py
+++ b/cloudify_cli/tests/commands/test_events.py
@@ -1,7 +1,7 @@
 import json
 import time
 
-from mock import patch
+from mock import patch, Mock
 
 from .test_base import CliCommandTest
 from .mocks import MockListResponse, mock_log_message_prefix
@@ -21,6 +21,7 @@ class EventsTest(CliCommandTest):
         self.events = self._generate_events(self.execution_start_time,
                                             self.execution_termination_time)
         self.executions_status = executions.Execution.STARTED
+        self.client.executions.list = Mock(return_value=MockListResponse())
 
     def _generate_events(self, start_time, end_time):
         events = []


### PR DESCRIPTION
Instead of just working with the execution id, it is useful to
provide a shorthand to use the last created execution for a given
workflow.

With this, the following calls are now allowed:
    cfy exec cancel install
    cfy exec resume install
    cfy events list uninstall
    cfy exec get execute_operation
etc