### PR TITLE
CY-1868 Add --rest-port to `profiles set`

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -788,7 +788,8 @@ class Options(object):
         self.rest_port = click.option(
             '--rest-port',
             required=False,
-            help=helptexts.REST_PORT)
+            help=helptexts.REST_PORT,
+            type=int)
 
         self.ssl_rest = click.option(
             '--ssl',

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -297,6 +297,7 @@ def set_profile(profile_name,
                 ssh_port,
                 ssl,
                 rest_certificate,
+                rest_port,
                 kerberos_env,
                 skip_credentials_validation,
                 logger):
@@ -347,6 +348,9 @@ def set_profile(profile_name,
         logger.info(
             'Setting rest certificate to `{0}`'.format(rest_certificate))
         env.profile.rest_certificate = rest_certificate
+    if rest_port:
+        logger.info('Setting rest port to `{0}'.format(rest_port))
+        env.profile.rest_port = rest_port
     if ssh_user:
         logger.info('Setting ssh user to `{0}`'.format(ssh_user))
         env.profile.ssh_user = ssh_user
@@ -408,6 +412,7 @@ def _set_profile_ssl(ssl, logger):
 @cfy.options.ssh_port
 @cfy.options.ssl_state
 @cfy.options.rest_certificate
+@cfy.options.rest_port
 @cfy.options.kerberos_env
 @cfy.options.skip_credentials_validation
 @cfy.options.common_options
@@ -421,6 +426,7 @@ def set_cmd(profile_name,
             ssh_port,
             ssl,
             rest_certificate,
+            rest_port,
             kerberos_env,
             skip_credentials_validation,
             logger):
@@ -433,6 +439,7 @@ def set_cmd(profile_name,
                        ssh_port,
                        _get_ssl_indication(ssl),
                        rest_certificate,
+                       rest_port,
                        get_kerberos_indication(kerberos_env),
                        skip_credentials_validation,
                        logger)

--- a/cloudify_cli/commands/ssl_cmd.py
+++ b/cloudify_cli/commands/ssl_cmd.py
@@ -56,6 +56,7 @@ def enable(logger, client):
                 ssh_port=None,
                 ssl=True,
                 rest_certificate=None,
+                rest_port=None,
                 kerberos_env=None,
                 skip_credentials_validation=True,
                 logger=logger)
@@ -82,6 +83,7 @@ def disable(logger, client):
                 ssh_port=None,
                 ssl=False,
                 rest_certificate=None,
+                rest_port=None,
                 kerberos_env=None,
                 skip_credentials_validation=True,
                 logger=logger)

--- a/cloudify_cli/tests/commands/test_profiles.py
+++ b/cloudify_cli/tests/commands/test_profiles.py
@@ -356,6 +356,15 @@ class ProfilesTest(CliCommandTest):
 
     @patch('cloudify_cli.commands.profiles._get_provider_context',
            return_value={})
+    def test_set_rest_port_overrides_protocol(self, *_):
+        self.invoke('profiles use 1.2.3.4')
+        self.invoke('profiles set --ssl on --rest-port 8090 '
+                    '--skip-credentials-validation')
+        added_profile = env.get_profile_context('1.2.3.4')
+        self.assertEqual(8090, added_profile.rest_port)
+
+    @patch('cloudify_cli.commands.profiles._get_provider_context',
+           return_value={})
     def test_use_cannot_update_profile(self, *_):
         self.use_manager()
         outcome = self.invoke('profiles use 10.10.1.10 -p abc')


### PR DESCRIPTION
It was available in `profiles use` but not in set.