### PR TITLE
CY-2249 `ssl enable`: don't update-profile with cluster nodes

### DIFF
--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -402,7 +402,6 @@ def _set_profile_ssl(ssl, rest_port, logger):
     env.profile.rest_port = port
     env.profile.rest_protocol = protocol
 
-    _update_cluster_profile_to_dict(logger)
     manager_cluster = env.profile.cluster.get(CloudifyNodeType.MANAGER)
     if manager_cluster:
         missing_certs = []


### PR DESCRIPTION
`cfy ssl enable` is supposed to just update the profile to enable ssl

It attempted to also do the equivalent of `cfy cluster update-profile`,
however that requires to contact the manager, and that isn't
necessarily possible (yet) because the manager might not have become
ssl (yet).

Anyway, we're updating the ssl setting for each manager. We're just
not updating the profile list (with any new managers that might
have been added in the meantime)

Alternatively we could've added a sleep, but just Not Doing It™
is simpler