### PR TITLE
Fix the helptext of the networks option

### DIFF
--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -375,7 +375,7 @@ DETACH_SITE = "If set, detach the current site, making the deployment " \
 WITH_LOGS = "If set, then the deployment's management workers logs are " \
             "deleted as well [default: False]"
 
-NETWORKS = "Networks as a JSON string or as '\'net1=ip1;net2=ip2\'). " \
+NETWORKS = "Networks as a JSON string or as \'net1=ip1;net2=ip2\'. " \
            "This argument can be used multiple times."
 
 PORT = "A non-default network port to use for this component."


### PR DESCRIPTION
The new description will be:
"Networks as a JSON string or as 'net1=ip1;net2=ip2'.
 This argument can be used multiple times."