### PR TITLE
CY-2456 Py3 porting: unicode changes

### DIFF
--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -305,8 +305,8 @@ def get(blueprint_id, logger, client, tenant_name):
 
         if blueprint_metadata:
             logger.info('Metadata:')
-            for property_name, property_value in utils.decode_dict(
-                    blueprint_dict['plan']['metadata']).items():
+            for property_name, property_value in \
+                    blueprint_dict['plan']['metadata'].items():
                 logger.info('\t{0}: {1}'.format(property_name, property_value))
             logger.info('')
 

--- a/cloudify_cli/commands/init.py
+++ b/cloudify_cli/commands/init.py
@@ -92,7 +92,6 @@ def init(blueprint_path,
             processed_blueprint_path,
             blueprint_filename
         )
-
         if os.path.isdir(local.storage_dir(blueprint_id)):
             shutil.rmtree(local.storage_dir(blueprint_id))
 
@@ -192,7 +191,7 @@ def _raise_initialized_error(profile_name):
 def set_config(enable_colors=False):
     cli_config = pkg_resources.resource_string(
         cloudify_cli.__name__,
-        'config/config_template.yaml')
+        'config/config_template.yaml').decode('utf-8')
 
     enable_colors = str(enable_colors).lower()
     template = Template(cli_config)

--- a/cloudify_cli/commands/maintenance_mode.py
+++ b/cloudify_cli/commands/maintenance_mode.py
@@ -16,7 +16,6 @@
 
 import time
 
-from .. import utils
 from ..cli import cfy
 from .. import exceptions
 from ..table import print_data
@@ -54,8 +53,7 @@ def _print_maintenance_mode_status(client, logger):
     status_response = client.maintenance_mode.status()
 
     logger.info('\nMaintenance Mode Status:')
-    for param_name, param_value in utils.decode_dict(
-            status_response).items():
+    for param_name, param_value in status_response.items():
         if param_value and param_name != 'remaining_executions':
             logger.info('\t{0}:\t{1}'.format(
                 param_name.title().replace("_", " "),

--- a/cloudify_cli/commands/node_instances.py
+++ b/cloudify_cli/commands/node_instances.py
@@ -263,10 +263,6 @@ def local(node_id, blueprint_id, logger):
 
 
 def _print_node_instance(node_instance):
-    # Decode in-place so that it's decoded for both branches
-    node_instance.runtime_properties.update(
-        utils.decode_dict(node_instance.runtime_properties))
-
     if get_global_json_output():
         # For json output, make sure runtime properties are in the same object
         # so that the output is a single decode-able object

--- a/cloudify_cli/commands/nodes.py
+++ b/cloudify_cli/commands/nodes.py
@@ -99,7 +99,7 @@ def get(node_id, deployment_id, logger, client, tenant_name):
         print_details(node.properties, 'Node properties:')
 
         operations = []
-        for op_name, op in utils.decode_dict(node.operations).items():
+        for op_name, op in node.operations.items():
             # operations is a tuple (operation_name, dict_of_attributes)
             # we want to add the name to the dict
             # and build a new array in order to print it in a table

--- a/cloudify_cli/commands/workflows.py
+++ b/cloudify_cli/commands/workflows.py
@@ -76,8 +76,7 @@ def get(workflow_id, deployment_id, logger, client, tenant_name):
         # print workflow parameters
         mandatory_params = dict()
         optional_params = dict()
-        for param_name, param in utils.decode_dict(
-                workflow.parameters).items():
+        for param_name, param in workflow.parameters.items():
             params_group = optional_params if 'default' in param else \
                 mandatory_params
             params_group[param_name] = param

--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -513,8 +513,9 @@ def get_auth_header(username, password):
     header = {}
 
     if username and password:
-        credentials = '{0}:{1}'.format(username, password)
-        encoded_credentials = urlsafe_b64encode(credentials)
+        # encode/decode just to allow urlsafe_b64encode, which requires bytes
+        credentials = '{0}:{1}'.format(username, password).encode('utf-8')
+        encoded_credentials = urlsafe_b64encode(credentials).decode('utf-8')
         header = {
             constants.CLOUDIFY_AUTHENTICATION_HEADER:
                 constants.BASIC_AUTH_PREFIX + ' ' + encoded_credentials}

--- a/cloudify_cli/inputs.py
+++ b/cloudify_cli/inputs.py
@@ -18,6 +18,8 @@ import os
 import glob
 import yaml
 
+from cloudify._compat import text_type
+
 from .utils import deep_update_dict, insert_dotted_key_to_dict
 
 from .logger import get_logger
@@ -46,7 +48,7 @@ def inputs_to_dict(resources, **kwargs):
     for resource in resources:
         logger.debug('Processing inputs source: {0}'.format(resource))
         # Workflow parameters always pass an empty dictionary. We ignore it
-        if isinstance(resource, basestring):
+        if isinstance(resource, (text_type, bytes)):
             try:
                 if kwargs.get('dot_hierarchy'):
                     deep_update_dict(parsed_dict,

--- a/cloudify_cli/table.py
+++ b/cloudify_cli/table.py
@@ -21,6 +21,8 @@ from datetime import datetime
 from prettytable import PrettyTable
 from .logger import get_global_json_output, CloudifyJSONEncoder, output
 
+from cloudify._compat import text_type
+
 
 def generate(cols, data, defaults=None, labels=None):
     """
@@ -53,7 +55,7 @@ def generate(cols, data, defaults=None, labels=None):
 
     def get_values_per_column(column, row_data):
         if column in row_data:
-            if row_data[column] and isinstance(row_data[column], basestring):
+            if row_data[column] and isinstance(row_data[column], text_type):
                 row_data[column] = get_timestamp(row_data[column]) \
                     or row_data[column]
             elif row_data[column] and isinstance(row_data[column], list):

--- a/cloudify_cli/tests/commands/test_install.py
+++ b/cloudify_cli/tests/commands/test_install.py
@@ -43,11 +43,11 @@ class InstallTest(CliCommandTest):
 
         self.assertEqual(
             blueprint_upload_args['blueprint_filename'],
-            unicode(DEFAULT_BLUEPRINT_FILE_NAME)
+            DEFAULT_BLUEPRINT_FILE_NAME
         )
         self.assertEqual(
             blueprint_upload_args['blueprint_id'],
-            unicode(STUB_BLUEPRINT_ID)
+            STUB_BLUEPRINT_ID
         )
 
     @patch('cloudify_cli.commands.executions.manager_start')
@@ -67,11 +67,11 @@ class InstallTest(CliCommandTest):
 
         self.assertEqual(
             blueprint_upload_args['blueprint_filename'],
-            unicode(DEFAULT_BLUEPRINT_FILE_NAME)
+            DEFAULT_BLUEPRINT_FILE_NAME
         )
         self.assertEqual(
             blueprint_upload_args['blueprint_id'],
-            unicode(STUB_DIRECTORY_NAME)
+            STUB_DIRECTORY_NAME
         )
 
     @patch('cloudify_cli.commands.executions.manager_start')
@@ -91,11 +91,11 @@ class InstallTest(CliCommandTest):
 
         self.assertEqual(
             blueprint_upload_args['blueprint_filename'],
-            unicode(DEFAULT_BLUEPRINT_FILE_NAME)
+            DEFAULT_BLUEPRINT_FILE_NAME
         )
         self.assertEqual(
             blueprint_upload_args['blueprint_id'],
-            u'cloudify-hello-world-example-master'
+            'cloudify-hello-world-example-master'
         )
 
     @patch('cloudify_cli.commands.blueprints.upload')
@@ -112,14 +112,13 @@ class InstallTest(CliCommandTest):
         deployment_create_args = deployment_create_mock.call_args_list[0][1]
 
         self.assertDictEqual(deployment_create_args, {
-            'blueprint_id': unicode(STUB_BLUEPRINT_ID),
-            'deployment_id': unicode(STUB_BLUEPRINT_ID),
+            'blueprint_id': STUB_BLUEPRINT_ID,
+            'deployment_id': STUB_BLUEPRINT_ID,
             'inputs': {'key1': 'val1', 'key2': 'val2'},
             'skip_plugins_validation': False,
             'tenant_name': None,
             'visibility': 'tenant'
-        }
-                             )
+        })
 
     @patch('cloudify_cli.commands.blueprints.upload')
     @patch('cloudify_cli.commands.executions.manager_start')
@@ -139,14 +138,13 @@ class InstallTest(CliCommandTest):
         deployment_create_args = deployment_create_mock.call_args_list[0][1]
 
         self.assertDictEqual(deployment_create_args, {
-            'blueprint_id': unicode(STUB_BLUEPRINT_ID),
-            'deployment_id': unicode(STUB_DEPLOYMENT_ID),
+            'blueprint_id': STUB_BLUEPRINT_ID,
+            'deployment_id': STUB_DEPLOYMENT_ID,
             'inputs': {'key1': 'val1', 'key2': 'val2'},
             'skip_plugins_validation': False,
             'tenant_name': None,
             'visibility': 'tenant'
-        }
-                             )
+        })
 
     @patch('cloudify_cli.commands.blueprints.upload')
     @patch('cloudify_cli.commands.deployments.manager_create')
@@ -170,7 +168,7 @@ class InstallTest(CliCommandTest):
             executions_start_args,
             {
                 'allow_custom_parameters': False,
-                'deployment_id': unicode(STUB_DEPLOYMENT_ID),
+                'deployment_id': STUB_DEPLOYMENT_ID,
                 'force': False,
                 'include_logs': True,
                 'json_output': False,
@@ -197,9 +195,9 @@ class InstallTest(CliCommandTest):
         self.assertDictEqual(
             blueprints_upload_args,
             {
-                'blueprint_filename': unicode(DEFAULT_BLUEPRINT_FILE_NAME),
-                'blueprint_id': unicode(STUB_BLUEPRINT_ID),
-                'blueprint_path': unicode(SAMPLE_BLUEPRINT_PATH),
+                'blueprint_filename': DEFAULT_BLUEPRINT_FILE_NAME,
+                'blueprint_id': STUB_BLUEPRINT_ID,
+                'blueprint_path': SAMPLE_BLUEPRINT_PATH,
                 'validate': True,
                 'tenant_name': None,
                 'visibility': 'tenant'
@@ -225,12 +223,12 @@ class InstallTest(CliCommandTest):
 
         self.assertEqual(
             blueprints_upload_args['blueprint_filename'],
-            unicode(DEFAULT_BLUEPRINT_FILE_NAME)
+            DEFAULT_BLUEPRINT_FILE_NAME
         )
 
         self.assertEqual(
             blueprints_upload_args['blueprint_id'],
-            unicode(STUB_BLUEPRINT_ID)
+            STUB_BLUEPRINT_ID
         )
 
     @patch('cloudify_cli.commands.executions.manager_start')
@@ -252,8 +250,8 @@ class InstallTest(CliCommandTest):
         self.invoke(command, context='manager')
 
         deployments_create_mock.assert_called_with(
-            blueprint_id=unicode(STUB_BLUEPRINT_ID),
-            deployment_id=unicode(STUB_DEPLOYMENT_ID),
+            blueprint_id=STUB_BLUEPRINT_ID,
+            deployment_id=STUB_DEPLOYMENT_ID,
             inputs={'key1': 'val1', 'key2': 'val2'},
             tenant_name=None,
             visibility='tenant',
@@ -393,7 +391,7 @@ class InstallTest(CliCommandTest):
             {
                 'inputs': {},
                 'blueprint_id': 'local',
-                'blueprint_path': unicode(blueprint_path),
+                'blueprint_path': blueprint_path,
                 'install_plugins': False
             }
         )

--- a/cloudify_cli/tests/commands/test_node_instances.py
+++ b/cloudify_cli/tests/commands/test_node_instances.py
@@ -139,7 +139,7 @@ class NodeInstancesTest(CliCommandTest):
         self.client.node_instances.update = MagicMock(return_value={})
 
         yaml_path = tempfile.mktemp(suffix='.yaml')
-        with open(yaml_path, 'wb') as f:
+        with open(yaml_path, 'w') as f:
             f.write("""
                     x1:
                         y: 1
@@ -159,7 +159,7 @@ class NodeInstancesTest(CliCommandTest):
         self.client.node_instances.update = MagicMock(return_value={})
 
         yaml_path = tempfile.mktemp(suffix='.yaml')
-        with open(yaml_path, 'wb') as f:
+        with open(yaml_path, 'w') as f:
             f.write("""
                     x1:
                         y: 1
@@ -170,7 +170,7 @@ class NodeInstancesTest(CliCommandTest):
                     .format(yaml_path),
                     err_str_segment='is not a valid YAML',
                     exception=CloudifyCliError)
-        with open(yaml_path, 'wb') as f:
+        with open(yaml_path, 'w') as f:
             f.write("""
                     - x1
                     - x2
@@ -235,7 +235,7 @@ class NodeInstancesTest(CliCommandTest):
         self.client.node_instances.update = MagicMock(return_value={})
 
         yaml_path = tempfile.mktemp(suffix='.yaml')
-        with open(yaml_path, 'wb') as f:
+        with open(yaml_path, 'w') as f:
             f.write("""
                     x:
                         y:
@@ -245,7 +245,7 @@ class NodeInstancesTest(CliCommandTest):
         self.invoke('cfy node-instances update-runtime instance_id -p {0}'
                     .format(yaml_path))
         call_args = self.client.node_instances.update.call_args
-        with open(yaml_path, 'wb') as f:
+        with open(yaml_path, 'w') as f:
             f.write("""
                     x:
                         y:

--- a/cloudify_cli/utils.py
+++ b/cloudify_cli/utils.py
@@ -71,34 +71,6 @@ def get_cwd():
     return os.getcwd()
 
 
-def decode_list(data):
-    rv = []
-    for item in data:
-        if isinstance(item, unicode):
-            item = item.encode('utf-8')
-        elif isinstance(item, list):
-            item = decode_list(item)
-        elif isinstance(item, dict):
-            item = decode_dict(item)
-        rv.append(item)
-    return rv
-
-
-def decode_dict(data):
-    rv = {}
-    for key, value in data.items():
-        if isinstance(key, unicode):
-            key = key.encode('utf-8')
-        if isinstance(value, unicode):
-            value = value.encode('utf-8')
-        elif isinstance(value, list):
-            value = decode_list(value)
-        elif isinstance(value, dict):
-            value = decode_dict(value)
-        rv[key] = value
-    return rv
-
-
 def remove_if_exists(path):
 
     try:


### PR DESCRIPTION
See commit by commit.

Especially see what I think about things like decode_dict/decode_list:
functions like that are VERY WRONG, they go against the idea of the
"unicode sandwich" - if it's already a list/dict, it means it was already
loaded (from json, usually), so it should already be unicode. There is
NO REASON to go through a list and decode/encode every item in it.
That is the WRONG level to do it. The list should be first serialized
(json), and only after that, encoded.