### PR TITLE
Make `cfy ssh` and fabric optional

### DIFF
--- a/cloudify_cli/commands/ssh.py
+++ b/cloudify_cli/commands/ssh.py
@@ -16,12 +16,16 @@
 
 import re
 
-from invoke.exceptions import UnexpectedExit
 
 from .. import env
 from .. import utils
 from ..cli import cfy
 from ..exceptions import CloudifyCliError
+
+try:
+    from invoke.exceptions import UnexpectedExit
+except ImportError:
+    UnexpectedExit = Exception
 
 
 @cfy.command(name='ssh', short_help='Connect using SSH [manager only]')

--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -26,8 +26,6 @@ from contextlib import contextmanager
 
 import yaml
 import requests
-from fabric import Connection
-from paramiko import AuthenticationException
 
 from cloudify_rest_client import CloudifyClient
 from cloudify_rest_client.client import HTTPClient
@@ -37,6 +35,13 @@ from cloudify_rest_client.exceptions import CloudifyClientError
 
 from . import constants
 from .exceptions import CloudifyCliError
+
+try:
+    from fabric import Connection
+    from paramiko import AuthenticationException
+except ImportError:
+    Connection = None
+
 
 _ENV_NAME = 'manager'
 DEFAULT_LOG_FILE = os.path.expanduser(
@@ -646,6 +651,9 @@ class CloudifyClusterClient(CloudifyClient):
 
 @contextmanager
 def ssh_connection(host=None, user=None, key=None):
+    if Connection is None:
+        raise CloudifyCliError(
+            "SSH not available - fabric not installed")
     if host is None:
         host = profile.manager_ip
     if user is None:

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         'click==6.7',
         'wagon[venv]==0.6.3',
         'pyyaml==3.10',
-        'fabric==2.5.0',
         'jinja2==2.10',
         'retrying==1.3.3',
         'colorama==0.3.3',
@@ -53,5 +52,8 @@ setup(
         'backports.shutil_get_terminal_size==1.0.0',
         'ipaddress==1.0.19',
         'setuptools<=40.7.3'
-    ]
+    ],
+    extras_require={
+        'ssh': ['fabric==2.5.0']
+    }
 )


### PR DESCRIPTION
For now, make the ssh subsystem an optional dependency.
This is so that the CLI can work with the current
cloudify-fabric-plugin.

This can/will possibly be reverted later, after the fabric-plugin
is ported, or after plugins are made to be installed
into separate virtualenvs.

For now, this should fix the build, anyway.