### PR TITLE
CY-2725 Filtering events delete by timestamp range (#1081)

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -22,6 +22,8 @@ import StringIO
 import warnings
 import traceback
 from functools import wraps
+import datetime
+import re
 
 import click
 from cloudify_rest_client.constants import VisibilityState
@@ -82,6 +84,34 @@ class MutuallyExclusiveOption(click.Option):
             )
         return super(MutuallyExclusiveOption, self).handle_parse_result(
             ctx, opts, args)
+
+
+def _parse_relative_datetime(ctx, param, rel_datetime):
+    """Change relative time (ago) to a valid timestamp"""
+    if not rel_datetime:
+        return None
+    parsed = re.findall(r"(\d+) (seconds?|minutes?|hours?|days?|weeks?"
+                        "|months?|years?) ?(ago)?",
+                        rel_datetime)
+    if not parsed or len(parsed[0]) < 2:
+        return None
+    number = int(parsed[0][0])
+    period = parsed[0][1]
+    if period[-1] != u's':
+        period += u's'
+    now = datetime.datetime.utcnow()
+    if period == u'years':
+        result = now.replace(year=now.year - number)
+    elif period == u'months':
+        if now.month > number:
+            result = now.replace(month=now.month - number)
+        else:
+            result = now.replace(month=now.month - number + 12,
+                                 year=now.year - 1)
+    else:
+        delta = datetime.timedelta(**{period: number})
+        result = now - delta
+    return result.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
 
 
 def _format_version_data(version_data,
@@ -1409,6 +1439,67 @@ class Options(object):
             '--yaml-path',
             required=True,
             help=helptexts.PLUGIN_YAML_PATH)
+
+    @staticmethod
+    def from_datetime(required=False, mutually_exclusive_with=None,
+                      help=helptexts.FROM_DATETIME):
+        kwargs = {
+            'required': required,
+            'type': str,
+            'help': help,
+        }
+        if mutually_exclusive_with:
+            kwargs['cls'] = MutuallyExclusiveOption
+            kwargs['mutually_exclusive'] = mutually_exclusive_with
+        return click.option('from_datetime', '--from', **kwargs)
+
+    @staticmethod
+    def to_datetime(required=False, mutually_exclusive_with=None,
+                    help=helptexts.TO_DATETIME):
+        kwargs = {
+            'required': required,
+            'type': str,
+            'help': help,
+        }
+        if mutually_exclusive_with:
+            kwargs['cls'] = MutuallyExclusiveOption
+            kwargs['mutually_exclusive'] = mutually_exclusive_with
+        return click.option('to_datetime', '--to', **kwargs)
+
+    @staticmethod
+    def before(required=False,
+               mutually_exclusive_with=None,
+               help=helptexts.BEFORE):
+        kwargs = {
+            'required': required,
+            'type': str,
+            'callback': _parse_relative_datetime,
+            'expose_value': True,
+            'help': help,
+        }
+        if mutually_exclusive_with:
+            kwargs['cls'] = MutuallyExclusiveOption
+            kwargs['mutually_exclusive'] = mutually_exclusive_with
+        return click.option('--before', **kwargs)
+
+    @staticmethod
+    def store_before(default=False):
+        return click.option(
+            '--store-before',
+            is_flag=True,
+            default=default,
+            help=helptexts.STORE_BEFORE_DELETION
+        )
+
+    @staticmethod
+    def store_output_path():
+        return click.option(
+            '-o',
+            '--output-path',
+            required=False,
+            type=click.Path(file_okay=True, dir_okay=False),
+            help=helptexts.STORE_OUTPUT_PATH
+        )
 
 
 options = Options()

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -318,3 +318,10 @@ WAIT_AFTER_FAIL = 'When a task fails, wait this many seconds for ' \
                   'already-running tasks to return'
 RESET_OPERATIONS = 'Reset operations in started state, so that they are '\
                    'ran again unconditionally'
+
+FROM_DATETIME = "Beginning of a period"
+TO_DATETIME = "End of a period"
+BEFORE = "How long ago did the specified period ended"
+
+STORE_BEFORE_DELETION = "List and store events before deleting them"
+STORE_OUTPUT_PATH = "Store listed events to a specified file (cli side)"

--- a/cloudify_cli/commands/events.py
+++ b/cloudify_cli/commands/events.py
@@ -16,6 +16,8 @@
 
 from cloudify_rest_client.exceptions import CloudifyClientError
 
+from cloudify import logs
+
 import click
 
 from .. import utils
@@ -44,6 +46,13 @@ def events():
 @cfy.options.tail
 @cfy.options.common_options
 @cfy.options.tenant_name(required=False, resource_name_for_help='execution')
+@cfy.options.from_datetime(required=False,
+                           help="Events that occurred at this timestamp"
+                                " or after will be listed")
+@cfy.options.to_datetime(required=False,
+                         mutually_exclusive_with=['tail'],
+                         help="Events that occurred at this timestamp"
+                              " or before will be listed",)
 @cfy.options.pagination_offset
 @cfy.options.pagination_size
 @cfy.pass_client()
@@ -54,10 +63,13 @@ def list(execution_id,
          json_output,
          tail,
          tenant_name,
+         from_datetime,
+         to_datetime,
          pagination_offset,
          pagination_size,
          client,
          logger):
+    """Display events for an execution"""
     if execution_id and execution_id_opt:
         raise click.UsageError(
             "Execution ID provided both as a positional "
@@ -75,8 +87,6 @@ def list(execution_id,
                        "is now deprecated. Please provide the execution ID as "
                        "a positional argument.")
 
-    """Display events for an execution
-    """
     utils.explicit_tenant_name_message(tenant_name, logger)
     logger.info('Listing events for execution id {0} '
                 '[include_logs={1}]'.format(execution_id, include_logs))
@@ -84,7 +94,9 @@ def list(execution_id,
         execution_events = ExecutionEventsFetcher(
             client,
             execution_id,
-            include_logs=include_logs
+            include_logs=include_logs,
+            from_datetime=from_datetime,
+            to_datetime=to_datetime,
         )
 
         events_logger = get_events_logger(json_output)
@@ -94,7 +106,8 @@ def list(execution_id,
                                            client.executions.get(execution_id),
                                            events_handler=events_logger,
                                            include_logs=include_logs,
-                                           timeout=None)  # don't timeout ever
+                                           timeout=None,  # don't timeout ever
+                                           from_datetime=from_datetime)
             if execution.error:
                 logger.info('Execution of workflow {0} for deployment '
                             '{1} failed. [error={2}]'.format(
@@ -130,25 +143,102 @@ def list(execution_id,
 @cfy.options.include_logs
 @cfy.options.common_options
 @cfy.options.tenant_name(required=False, resource_name_for_help='deployment')
+@cfy.options.from_datetime(required=False,
+                           help="Events that occurred at this timestamp"
+                                " or after will be deleted")
+@cfy.options.to_datetime(required=False,
+                         mutually_exclusive_with=['before'],
+                         help="Events that occurred at this timestamp"
+                              " or before will be deleted")
+@cfy.options.before(required=False,
+                    mutually_exclusive_with=['to_datetime'],
+                    help="Events that occurred this long ago or earlier"
+                         "will be deleted")
+@cfy.options.store_before()
+@cfy.options.store_output_path()
 @cfy.pass_client()
 @cfy.pass_logger
-def delete(deployment_id, include_logs, logger, client, tenant_name):
+def delete(deployment_id, include_logs, logger, client, tenant_name,
+           from_datetime, to_datetime, before, store_before, output_path):
     """Delete events attached to a deployment
 
-    `EXECUTION_ID` is the execution events to delete.
+    `DEPLOYMENT_ID` is the deployment_id of the executions from which
+    events/logs are deleted.
     """
     utils.explicit_tenant_name_message(tenant_name, logger)
+    if before:
+        to_datetime = before
+    filter_info = {'include_logs': u'{0}'.format(include_logs)}
+    if from_datetime:
+        filter_info['from_datetime'] = u'{0}'.format(from_datetime)
+    if to_datetime:
+        filter_info['to_datetime'] = u'{0}'.format(to_datetime)
     logger.info(
-        'Deleting events for deployment id {0} [include_logs={1}]'.format(
-            deployment_id, include_logs))
+        'Deleting events for deployment id {0} [{1}]'.format(
+            deployment_id,
+            u', '.join([u'{0}={1}'.format(k, v) for k, v in
+                        filter_info.items()])))
 
     # Make sure the deployment exists - raise 404 otherwise
     client.deployments.get(deployment_id)
+
+    # List events prior to their deletion
+    if store_before and output_path:
+        exec_list = client.executions.list(deployment_id=deployment_id,
+                                           include_system_workflows=True,
+                                           _all_tenants=True)
+        with open(output_path, 'w') as output_file:
+            click.echo(
+                'Events for deployment id {0} [{1}]'.format(
+                    deployment_id,
+                    u', '.join([u'{0}={1}'.format(k, v) for k, v in
+                                filter_info.items()])),
+                file=output_file,
+                nl=True)
+            events_logger = DeletedEventsLogger(output_file)
+            for execution in exec_list:
+                execution_events = ExecutionEventsFetcher(
+                    client, execution.id, include_logs=include_logs,
+                    from_datetime=from_datetime, to_datetime=to_datetime)
+                output_file = open(output_path, 'a') if output_path else None
+                click.echo(
+                    '\nListing events for execution id {0}\n'.format(
+                        execution.id),
+                    file=output_file,
+                    nl=True)
+                total_events = execution_events.fetch_and_process_events(
+                    events_handler=events_logger.log)
+                click.echo(
+                    '\nListed {0} events'.format(total_events),
+                    file=output_file,
+                    nl=True)
+
+    # Delete events
+    delete_args = {}
+    if store_before and not output_path:
+        delete_args['store_before'] = 'true'
     deleted_events_count = client.events.delete(
-        deployment_id, include_logs=include_logs
-    )
+        deployment_id, include_logs=include_logs,
+        from_datetime=from_datetime, to_datetime=to_datetime,
+        **delete_args)
     deleted_events_count = deleted_events_count.items[0]
     if deleted_events_count:
         logger.info('\nDeleted {0} events'.format(deleted_events_count))
     else:
         logger.info('\nNo events to delete')
+
+
+class DeletedEventsLogger(object):
+    def __init__(self, output_file=None):
+        self._output_file = output_file
+
+    def log(self, events):
+        """The default events logger prints events as short messages.
+
+        :param events: The events to print.
+        :return:
+        """
+        for event in events:
+            output = logs.create_event_message_prefix(event)
+            if output:
+                click.echo(output, file=self._output_file)

--- a/cloudify_cli/execution_events_fetcher.py
+++ b/cloudify_cli/execution_events_fetcher.py
@@ -42,12 +42,16 @@ class ExecutionEventsFetcher(object):
                  client,
                  execution_id,
                  batch_size=100,
-                 include_logs=False):
+                 include_logs=False,
+                 from_datetime=None,
+                 to_datetime=None):
         self._client = client
         self._execution_id = execution_id
         self._batch_size = batch_size
         self._from_event = 0
         self._include_logs = include_logs
+        self._from_datetime = from_datetime
+        self._to_datetime = to_datetime
         # make sure execution exists before proceeding
         # a 404 will be raised otherwise
         self._client.executions.get(execution_id)
@@ -75,7 +79,9 @@ class ExecutionEventsFetcher(object):
             _offset=offset,
             _size=size,
             include_logs=self._include_logs,
-            sort='reported_timestamp')
+            sort='reported_timestamp',
+            from_datetime=self._from_datetime,
+            to_datetime=self._to_datetime)
         self._from_event += len(events_list_response)
         return events_list_response
 
@@ -185,7 +191,8 @@ def wait_for_execution(client,
                        events_handler=None,
                        include_logs=False,
                        timeout=900,
-                       logger=None):
+                       logger=None,
+                       from_datetime=None):
 
     # if execution already ended - return without waiting
     if execution.status in Execution.END_STATES:
@@ -196,7 +203,8 @@ def wait_for_execution(client,
 
     events_fetcher = ExecutionEventsFetcher(client,
                                             execution.id,
-                                            include_logs=include_logs)
+                                            include_logs=include_logs,
+                                            from_datetime=from_datetime)
 
     # Poll for execution status and execution logs, until execution ends
     # and we receive an event of type in WORKFLOW_END_TYPES


### PR DESCRIPTION
This patch is accompanied by the other one in cloudify-manager where
deletion is actually performed.

* Add `--from` and `--to` options to the `cfy events delelete` command.

* Add filtering for events list by timestamp range

* Add `--from` and `--to` options to the `cfy events list` command.

* Add listing of events prior to deletion

* Two additional parameters added to `cfy events delete`:
 `--list-before` list/store events before deleting them.
 `-o, --output-path <PATH>`  save listed events to a specified file

* Verbose end of period definition for events delete (`--before`)
```cfy events delete --before "3 months" test-deployment```

* Write deleted events description to output file

* Don't list deleted events to stdout

If `--list-before` flag is enabled and `--output-path` parameters is
added to the `cfy events delete` command, the listing before delation
happens on cli side.  If `--list-before` is enabled but `--output-path`
is not, the listing (and storing) of deleted events happens on
manager's side.

* Use datetime instead of strings for dates

* Add test_delete_events_timeperiod