### PR TITLE
CY-3302 Add installation state to plugin get/list

### DIFF
--- a/cloudify_cli/commands/plugins.py
+++ b/cloudify_cli/commands/plugins.py
@@ -301,6 +301,9 @@ def list(sort_by,
         plugin['installed on'] = _format_installation_state(plugin)
     columns = PLUGIN_COLUMNS + GET_DATA_COLUMNS if get_data else PLUGIN_COLUMNS
 
+    if get_global_json_output():
+        columns += ['installation_state']
+
     print_data(columns, plugins_list, 'Plugins:')
     total = plugins_list.metadata.pagination.total
     logger.info('Showing {0} of {1} plugins'.format(len(plugins_list),

--- a/cloudify_cli/commands/plugins.py
+++ b/cloudify_cli/commands/plugins.py
@@ -44,7 +44,8 @@ PLUGIN_COLUMNS = ['id', 'package_name', 'package_version', 'installed on',
 PLUGINS_UPDATE_COLUMNS = ['id', 'state', 'blueprint_id', 'temp_blueprint_id',
                           'execution_id', 'deployments_to_update',
                           'visibility', 'created_at', 'forced']
-GET_DATA_COLUMNS = ['file_server_path']
+GET_DATA_COLUMNS = ['file_server_path', 'supported_platform', 'distribution',
+                    'supported_py_versions', 'distribution_release']
 
 
 @cfy.group(name='plugins')
@@ -250,14 +251,16 @@ def get(plugin_id, logger, client, tenant_name, get_data):
         print_single(columns + ['installation_state'], plugin, 'Plugin:', 50)
         return
 
-    print_single(columns, plugin, 'Plugin:')
     states = {}
-    for state in plugin['installation_state']:
+    for state in plugin.pop('installation_state', []):
         if state.get('manager'):
             label = 'Manager {0}'.format(state['manager'])
         elif state.get('agent'):
             label = 'Agent {0}'.format(state['agent'])
         states[label] = state['state']
+    print_details({
+        col: plugin.get(col) for col in columns
+    }, 'Plugin:')
     print_details(states, 'Plugin installation state:')
 
 


### PR DESCRIPTION
Move a few things around, too.

Anyway, this formats the installation state into a `installed on`
column that says eg. "1 managers, 2 agents" or "3 managers, 5 errors"
etc.
Then, in `get`, it actually shows you the names.