### PR TITLE
CY-3552 Use b64encode for creating credentials.

### DIFF
--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -21,7 +21,7 @@ import shutil
 import getpass
 import tempfile
 import itertools
-from base64 import urlsafe_b64encode
+from base64 import b64encode
 from contextlib import contextmanager
 
 import yaml
@@ -518,9 +518,9 @@ def get_auth_header(username, password):
     header = {}
 
     if username and password:
-        # encode/decode just to allow urlsafe_b64encode, which requires bytes
+        # encode/decode just to allow b64encode, which requires bytes
         credentials = '{0}:{1}'.format(username, password).encode('utf-8')
-        encoded_credentials = urlsafe_b64encode(credentials).decode('utf-8')
+        encoded_credentials = b64encode(credentials).decode('utf-8')
         header = {
             constants.CLOUDIFY_AUTHENTICATION_HEADER:
                 constants.BASIC_AUTH_PREFIX + ' ' + encoded_credentials}


### PR DESCRIPTION
As opposed to urlsafe_b64encode.

No reason for this to be urlsafe. At all.

Also, urlsafe breaks, because flask uses the non-urlsafe version
when decoding: https://github.com/pallets/werkzeug/blob/bbc5cbb8390d8d9de4fff42456cab3d91b85b584/src/werkzeug/http.py#L622
(this is for making `request.authorization`, which we then use).
Also, the basic auth rfc (RFC 7617) talks about using the plain version
of base64, not an urlsafe variant.

It needs to be encoded the same way it's going to be decoded.