### PR TITLE
CY-3580 Default --manager-tenant to default_tenant

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -866,14 +866,6 @@ class Options(object):
             default=False,
             help=helptexts.MANAGER_PASSWORD)
 
-        self.manager_tenant = click.option(
-            '-t',
-            '--manager-tenant',
-            required=False,
-            help=helptexts.MANAGER_TENANT,
-            callback=validate_name
-        )
-
         self.manager_tenant_flag = click.option(
             '-t',
             '--manager-tenant',
@@ -1867,6 +1859,17 @@ class Options(object):
             required=False,
             type=click.Path(file_okay=True, dir_okay=False),
             help=helptexts.STORE_OUTPUT_PATH
+        )
+
+    @staticmethod
+    def manager_tenant(default=None):
+        return click.option(
+            '-t',
+            '--manager-tenant',
+            required=False,
+            help=helptexts.MANAGER_TENANT,
+            callback=validate_name,
+            default=default
         )
 
 

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -148,7 +148,7 @@ def profiles_list(logger):
 @cfy.options.ssh_port
 @cfy.options.manager_username
 @cfy.options.manager_password
-@cfy.options.manager_tenant
+@cfy.options.manager_tenant(default='default_tenant')
 @cfy.options.rest_port
 @cfy.options.ssl_rest
 @cfy.options.rest_certificate
@@ -424,7 +424,7 @@ def _set_profile_ssl(ssl, rest_port, logger):
 @cfy.options.profile_name
 @cfy.options.manager_username
 @cfy.options.manager_password
-@cfy.options.manager_tenant
+@cfy.options.manager_tenant()
 @cfy.options.ssh_user
 @cfy.options.ssh_key
 @cfy.options.ssh_port


### PR DESCRIPTION
As the name suggests, this will now be the default tenant.

This allows `cfy profiles use` to run without `-t`, and it will
default to default_tenant.

Think of all the keypresses saved over the years.