### PR TITLE
CY-3617 events list --tail: follow resumed executions

### DIFF
--- a/cloudify_cli/execution_events_fetcher.py
+++ b/cloudify_cli/execution_events_fetcher.py
@@ -231,10 +231,8 @@ def wait_for_execution(client,
             execution = client.executions.get(execution.id)
             execution_ended = execution.status in Execution.END_STATES
 
-        if not events_watcher.end_log_received and \
-                execution.status != Execution.PENDING:
-            events_fetcher.fetch_and_process_events(
-                events_handler=events_watcher, timeout=timeout)
+        events_fetcher.fetch_and_process_events(
+            events_handler=events_watcher, timeout=timeout)
 
         if execution_ended and events_watcher.end_log_received:
             break


### PR DESCRIPTION
In wait_for_execution, call fetch_process_events every loop,
and remove the condition.

The condition was wrong because:
  - `not events_watcher.end_log_received`: this was not the case
    when resuming an execution, which already had a "ended" log
    before. The loop will be exited anyway, by the next `break`
  - `execution.status != Execution.PENDING`: this is just unnecessary,
    because this function is never really run for PENDING executions.
    And if it was, let's fetch the events as we go, instead of
    just silently iterating (yes, we would be iterating anyway!)