### PR TITLE
CY-3638 agent install: fetch all node-instances

### DIFF
--- a/cloudify_cli/tests/commands/test_agents.py
+++ b/cloudify_cli/tests/commands/test_agents.py
@@ -236,6 +236,15 @@ class AgentsTests(CliCommandTest):
             'other_tenant': {
                 'd0': {
                     'node_ids': ['node1']
+                },
+                # filtering by just node-id, still returns deployments
+                # that don't have that node; unfortunate but this is an
+                # optimization for the common case
+                'd1': {
+                    'node_ids': ['node1']
+                },
+                'd2': {
+                    'node_ids': ['node1']
                 }
             }
         }, results)

--- a/cloudify_cli/tests/commands/test_agents.py
+++ b/cloudify_cli/tests/commands/test_agents.py
@@ -98,7 +98,15 @@ class AgentsTests(CliCommandTest):
                     ni_node_id in kwargs.get('node_id', [ni_node_id]) and \
                     ni_dep_id in kwargs.get('deployment_id', [ni_dep_id])
 
-            return _topology_filter(_matcher, **kwargs)
+            instances = _topology_filter(_matcher, **kwargs)
+            return ListResponse(
+                instances, {
+                    'pagination': {
+                        'total': len(instances),
+                        'offset': 0,
+                        'size': len(instances)
+                    }
+                })
 
         def list_deployments(**kwargs):
             tenant_name = self.client._client.headers.get(
@@ -115,7 +123,7 @@ class AgentsTests(CliCommandTest):
             for dep in deployments:
                 if (not searched_ids) or dep.id in searched_ids:
                     results.append(dep)
-            return results
+            return ListResponse(results, {})
 
         def list_nodes(**kwargs):
             node_ids = kwargs.get('id')
@@ -125,8 +133,8 @@ class AgentsTests(CliCommandTest):
             nodes = [Node({'id': c, 'deployment_id': b, 'tenant_name': a}) for
                      (a, b, c) in nodes]
             if node_ids is None:
-                return nodes
-            return [x for x in nodes if x['id'] in node_ids]
+                nodes = [x for x in nodes if x['id'] in node_ids]
+            return ListResponse(nodes, {})
 
         self.client.node_instances.list = list_node_instances
         self.client.deployments.list = list_deployments

--- a/cloudify_cli/tests/commands/test_agents.py
+++ b/cloudify_cli/tests/commands/test_agents.py
@@ -289,6 +289,31 @@ class AgentsTests(CliCommandTest):
             AgentsTests._agent_filters(deployment_ids=['error']),
             False)
 
+    def test_filters_node_instance_pagination(self):
+        # with 2000 node-instances, the deployment with only uninitialized
+        # instances is skipped
+        self.mock_client([
+            _node_instance(
+                DEFAULT_TENANT_NAME,
+                'ni1_{0}'.format(i),
+                'node1',
+                'd0')
+            for i in range(2000)
+        ] + [
+            _node_instance(DEFAULT_TENANT_NAME, 'ni2_1', 'node2', 'd1'),
+            _node_instance(DEFAULT_TENANT_NAME, 'ni3_1', 'node3', 'd2',
+                           state='uninitialized')
+        ])
+        filters = get_filters_map(
+            self.client,
+            self.logger,
+            AgentsTests._agent_filters(),
+            False
+        )
+        self.assertIn('d0', filters[DEFAULT_TENANT_NAME])
+        self.assertIn('d1', filters[DEFAULT_TENANT_NAME])
+        self.assertNotIn('d2', filters[DEFAULT_TENANT_NAME])
+
     # Tests for get_deployments_and_run_workers
 
     def test_empty_node_instances_map(self):

--- a/cloudify_cli/tests/commands/test_agents.py
+++ b/cloudify_cli/tests/commands/test_agents.py
@@ -99,12 +99,15 @@ class AgentsTests(CliCommandTest):
                     ni_dep_id in kwargs.get('deployment_id', [ni_dep_id])
 
             instances = _topology_filter(_matcher, **kwargs)
+            total = len(instances)
+            offset, size = kwargs.get('_offset', 0), kwargs.get('_size', 1000)
+            instances = instances[offset:offset + size]
             return ListResponse(
                 instances, {
                     'pagination': {
-                        'total': len(instances),
-                        'offset': 0,
-                        'size': len(instances)
+                        'size': size,
+                        'offset': offset,
+                        'total': total
                     }
                 })
 


### PR DESCRIPTION
Instead of limiting the node-instance list by deployment id,
just fetch all of them.

We can't put the list of deployments in the filters, because
those filters go into the rest call URL, and with thousands of
deployments, we easily hit the URL size limit.

Instead, let's just fetch _all_ the node instances. That approach
is obviously correct, even if wasteful.

It is "wasteful" because we will be fetching node instances even
for deployments that we have already filtered out by using
the --node-id filter.
This means that this approach is going to be doing unnecessary
requests, and will be slower, for `cfy agents install --node-id x`.

However, using --node-id alone, without --deployment-id is
a very rare, and not a very useful, usecase, that's why I'm not
worried about making it slower.
(and anyway, it is going to be slower by the time it takes to
fetch node-instances, which pales in comparison to the time it takes
to actually run the agents install!)

Also, we used to only do a single request for the node-instances,
without following pagination. That's a separate bug in itself,
because it meant if there was more than one page worth of instances,
we would skip some.
Now we do follow pagination.