### PR TITLE
CY-3678 Use JSON for the profile context file

### DIFF
--- a/cloudify_cli/commands/init.py
+++ b/cloudify_cli/commands/init.py
@@ -150,7 +150,7 @@ def init_manager_profile(profile_name,
                          logger=None):
     logger.info('Initializing profile {0}...'.format(profile_name))
 
-    context_file_path = env.get_context_path(profile_name, suppress_error=True)
+    context_file_path = env.get_context_path(profile_name)
 
     if context_file_path and os.path.isfile(context_file_path):
         if reset_context:

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -41,7 +41,7 @@ from ..commands.cluster import update_profile_logic as update_cluster_profile
 EXPORTED_KEYS_DIRNAME = '.exported-ssh-keys'
 EXPORTED_SSH_KEYS_DIR = os.path.join(env.PROFILES_DIR, EXPORTED_KEYS_DIRNAME)
 PROFILE_COLUMNS = ['name', 'manager_ip', 'manager_username', 'manager_tenant',
-                   'ssh_user', 'ssh_key_path', 'ssh_port', 'kerberos_env',
+                   'ssh_user', 'ssh_key', 'ssh_port', 'kerberos_env',
                    'rest_port', 'rest_protocol', 'rest_certificate']
 CLUSTER_PROFILE_COLUMNS = PROFILE_COLUMNS[:1] + ['hostname', 'host_ip'] \
     + PROFILE_COLUMNS[2:]

--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -298,11 +298,11 @@ def delete(profile_name, logger):
     `PROFILE_NAME` is the IP of the manager the profile manages.
     """
     logger.info('Deleting profile {0}...'.format(profile_name))
-    try:
-        env.delete_profile(profile_name)
-        logger.info('Profile deleted')
-    except CloudifyCliError as ex:
-        logger.info(str(ex))
+    if not env.is_profile_exists(profile_name):
+        raise CloudifyCliError('Profile {0} does not exist'
+                               .format(profile_name))
+    env.delete_profile(profile_name)
+    logger.info('Profile deleted')
 
 
 def set_profile(profile_name,

--- a/cloudify_cli/constants.py
+++ b/cloudify_cli/constants.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 ############
 
-CLOUDIFY_PROFILE_CONTEXT_FILE_NAME = 'context'
 CLOUDIFY_BASE_DIRECTORY_NAME = '.cloudify'
 CONFIG_FILE_NAME = 'cloudify-config.yaml'
 DEFAULTS_CONFIG_FILE_NAME = 'cloudify-config.defaults.yaml'

--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -16,6 +16,8 @@
 
 
 import os
+import json
+import errno
 import types
 import shutil
 import getpass
@@ -164,26 +166,52 @@ def is_manager_active():
 
 
 def get_profile_context(profile_name=None, suppress_error=False):
-    # empty profile with nothing but default values
-    default = ProfileContext()
-    profile_name = profile_name or get_active_profile()
     if profile_name == 'local':
+        return ProfileContext({}, profile_name='local')
+
+    profile_name = profile_name or get_active_profile()
+    loaded = None
+    path = get_context_path(profile_name)
+    if path:
+        try:
+            with open(path) as f:
+                loaded = json.load(f)
+        except IOError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+    if not loaded:
+        loaded = _try_load_yaml_profile(profile_name)
+
+    if not loaded:
         if suppress_error:
-            return default
-        raise CloudifyCliError('Local profile does not have context')
+            return ProfileContext({})
+        raise CloudifyCliError('No context for profile {0}'
+                               .format(profile_name))
+    return ProfileContext(loaded, profile_name)
+
+
+def _try_load_yaml_profile(profile_name):
+    """Try to load the profile from the yaml context file.
+
+    This keeps compatibility with Cloudify 5.1 and earlier, who stored
+    the context in a yaml file. We will still load them, but we won't
+    store them anymore.
+    """
+    base_dir = get_profile_dir(profile_name)
+    if not base_dir:
+        return
     try:
-        path = get_context_path(profile_name)
-        with open(path) as f:
-            context = yaml.load(f.read())
-        # fill the default with values from existing profile (the default is
-        # used as base because some of the attributes may not be in the
-        # existing profile file)
-        for key, value in context.__dict__.items():
-            setattr(default, key, value)
-    except CloudifyCliError:
-        if not suppress_error:
+        with open(os.path.join(base_dir, 'context')) as f:
+            # dropping the object tag from yaml, so that we load the
+            # yaml as just a dict and not as an object
+            data = f.read().replace('!CloudifyProfileContext', '')
+            context = yaml.safe_load(data)
+    except IOError as e:
+        if e.errno != errno.ENOENT:
             raise
-    return default
+        return
+    return context
 
 
 def config_initialized_with_logging():
@@ -415,84 +443,48 @@ def get_manager_version_data(rest_client=None):
     return version_data
 
 
-class ProfileContext(yaml.YAMLObject):
-    yaml_tag = u'!CloudifyProfileContext'
-    yaml_loader = yaml.Loader
+class ProfileContext(object):
+    def __init__(self, context=None, profile_name=None):
+        self._context = {
+            'name': profile_name,
+            'manager_ip': None,
+            'ssh_key': None,
+            'ssh_port': 22,
+            'ssh_user': None,
+            'provider_context': {},
+            'manager_username': None,
+            'manager_password': None,
+            'manager_tenant': None,
+            'rest_port': constants.DEFAULT_REST_PORT,
+            'rest_protocol': constants.DEFAULT_REST_PROTOCOL,
+            'rest_certificate': None,
+            'kerberos_env': False,
+            'cluster': {}
+        }
+        if context:
+            self._context.update(context)
 
-    def __init__(self, profile_name=None):
-        # Note that __init__ is not called when loading from yaml.
-        # When adding a new ProfileContext attribute, make sure that
-        # all methods handle the case when the attribute is missing
-        self._profile_name = profile_name
-        self.manager_ip = None
-        self.ssh_key = None
-        self._ssh_port = None
-        self.ssh_user = None
-        self.provider_context = dict()
-        self.manager_username = None
-        self.manager_password = None
-        self.manager_tenant = None
-        self.rest_port = constants.DEFAULT_REST_PORT
-        self.rest_protocol = constants.DEFAULT_REST_PROTOCOL
-        self.rest_certificate = None
-        self.kerberos_env = False
-        self._cluster = dict()
+    def __getattr__(self, name):
+        return self._context[name]
+
+    def __setattr__(self, name, value):
+        if name in ['_context', 'profile_name']:
+            super(ProfileContext, self).__setattr__(name, value)
+        else:
+            self._context[name] = value
 
     def to_dict(self):
-        return dict(
-            name=self.profile_name,
-            manager_ip=self.manager_ip,
-            ssh_key_path=self.ssh_key,
-            ssh_port=self.ssh_port,
-            ssh_user=self.ssh_user,
-            provider_context=self.provider_context,
-            manager_username=self.manager_username,
-            manager_tenant=self.manager_tenant,
-            rest_port=self.rest_port,
-            rest_protocol=self.rest_protocol,
-            rest_certificate=self.rest_certificate,
-            kerberos_env=self.kerberos_env,
-            cluster=self.cluster
-        )
-
-    @property
-    def ssh_port(self):
-        return self._ssh_port
-
-    @ssh_port.setter
-    def ssh_port(self, ssh_port):
-        # If the port is int, we want to change it to a string. Otherwise,
-        # leave None as is
-        ssh_port = str(ssh_port) if ssh_port else None
-        self._ssh_port = ssh_port
+        ctx = self._context.copy()
+        ctx['name'] = self.profile_name
+        return ctx
 
     @property
     def profile_name(self):
-        return getattr(self, '_profile_name', None) \
-            or getattr(self, 'manager_ip', None)
-
-    @property
-    def cluster(self):
-        # default the ._cluster attribute here, so that all callers can use it
-        # as just ._cluster, even if it's not present in the source yaml
-        if not hasattr(self, '_cluster'):
-            self._cluster = dict()
-        return self._cluster
-
-    @cluster.setter
-    def cluster(self, cluster):
-        self._cluster = cluster
+        return self._context['name'] or self._context['manager_ip']
 
     @profile_name.setter
-    def profile_name(self, profile_name):
-        self._profile_name = profile_name
-
-    def _get_context_path(self):
-        init_path = get_profile_dir(self.profile_name)
-        context_path = os.path.join(
-            init_path,
-            constants.CLOUDIFY_PROFILE_CONTEXT_FILE_NAME)
-        return context_path
+    def profile_name(self, value):
+        self._context['name'] = value
 
     @property
     def workdir(self):
@@ -508,10 +500,10 @@ class ProfileContext(yaml.YAMLObject):
             os.makedirs(workdir)
         target_file_path = os.path.join(
             workdir,
-            constants.CLOUDIFY_PROFILE_CONTEXT_FILE_NAME)
-
+            'context.json')
         with open(target_file_path, 'w') as f:
-            f.write(yaml.dump(self))
+            json.dump(self.to_dict(), f, sort_keys=True, indent=4)
+            f.write('\n')
 
 
 def get_auth_header(username, password):

--- a/cloudify_cli/tests/__init__.py
+++ b/cloudify_cli/tests/__init__.py
@@ -3,7 +3,7 @@ import os
 from .. import env
 from ..config import config
 
-env.CLOUDIFY_WORKDIR = '/tmp/.cloudify-test'
+env.CLOUDIFY_WORKDIR = '/tmp/cloudify-cli-test/.cloudify'
 env.PROFILES_DIR = os.path.join(env.CLOUDIFY_WORKDIR, 'profiles')
 env.ACTIVE_PROFILE = os.path.join(env.CLOUDIFY_WORKDIR, 'active.profile')
 

--- a/cloudify_cli/tests/cfy.py
+++ b/cloudify_cli/tests/cfy.py
@@ -32,7 +32,7 @@ from .. import commands
 from .. import constants
 
 
-WORKDIR = os.path.join(tempfile.gettempdir(), '.cloudify-tests')
+WORKDIR = os.path.join(tempfile.gettempdir(), '.cloudify-cli-test')
 runner_lgr = setup_logger('cli_runner')
 
 

--- a/cloudify_cli/tests/cfy.py
+++ b/cloudify_cli/tests/cfy.py
@@ -39,7 +39,7 @@ runner_lgr = setup_logger('cli_runner')
 default_manager_params = dict(
     name='10.10.1.10',
     manager_ip='10.10.1.10',
-    ssh_key_path='key',
+    ssh_key='key',
     ssh_user='test',
     ssh_port='22',
     provider_context={},
@@ -147,7 +147,7 @@ def use_manager(**manager_params):
     provider_context = manager_params['provider_context'] or {}
     profile = env.ProfileContext()
     profile.manager_ip = manager_params['manager_ip']
-    profile.ssh_key = manager_params['ssh_key_path']
+    profile.ssh_key = manager_params['ssh_key']
     profile.ssh_user = manager_params['ssh_user']
     profile.ssh_port = manager_params['ssh_port']
     profile.rest_port = manager_params['rest_port']

--- a/cloudify_cli/tests/commands/constants.py
+++ b/cloudify_cli/tests/commands/constants.py
@@ -34,6 +34,7 @@ THIS_DIR = os.path.dirname(os.path.dirname(__file__))
 BLUEPRINTS_DIR = os.path.join(THIS_DIR, 'resources', 'blueprints')
 SNAPSHOTS_DIR = os.path.join(THIS_DIR, 'resources', 'snapshots')
 PLUGINS_DIR = os.path.join(THIS_DIR, 'resources', 'plugins')
+OLD_CONTEXT_PATH = os.path.join(THIS_DIR, 'resources', 'profile.yaml')
 SAMPLE_INPUTS_PATH = os.path.join(
     BLUEPRINTS_DIR, STUB_DIRECTORY_NAME, 'inputs.yaml')
 SAMPLE_BLUEPRINT_PATH = os.path.join(

--- a/cloudify_cli/tests/commands/test_profiles.py
+++ b/cloudify_cli/tests/commands/test_profiles.py
@@ -329,14 +329,6 @@ class ProfilesTest(CliCommandTest):
         p.manager_ip = '1.2.3.4'
         self.assertEquals('1.2.3.4', p.profile_name)
 
-        # pyyaml creates the object like that - skipping __init__; check that
-        # this doesn't break to allow correct handling pre-profile_name
-        # profiles
-        p = env.ProfileContext.__new__(env.ProfileContext)
-        self.assertIs(None, p.profile_name)
-        p.manager_ip = '1.2.3.4'
-        self.assertEquals('1.2.3.4', p.profile_name)
-
     @patch('cloudify_cli.commands.profiles._get_provider_context',
            return_value={})
     def test_use_defaults_ip_to_profile_name(self, *_):

--- a/cloudify_cli/tests/commands/test_profiles.py
+++ b/cloudify_cli/tests/commands/test_profiles.py
@@ -83,13 +83,13 @@ class ProfilesTest(CliCommandTest):
             self.invoke('cfy profiles export -o {0}'.format(profiles_archive))
             with closing(tarfile.open(name=profiles_archive)) as tar:
                 members = [member.name for member in tar.getmembers()]
-            self.assertIn('profiles/10.10.1.10/context', members)
+            self.assertIn('profiles/10.10.1.10/context.json', members)
             cfy.purge_dot_cloudify()
             self.assertFalse(os.path.isdir(env.PROFILES_DIR))
             self.invoke('cfy init')
             self.invoke('cfy profiles import {0}'.format(profiles_archive))
             self.assertTrue(os.path.isfile(
-                os.path.join(env.PROFILES_DIR, '10.10.1.10', 'context')))
+                os.path.join(env.PROFILES_DIR, '10.10.1.10', 'context.json')))
         finally:
             os.remove(profiles_archive)
 
@@ -113,7 +113,7 @@ class ProfilesTest(CliCommandTest):
                 profiles_archive))
             with closing(tarfile.open(name=profiles_archive)) as tar:
                 members = [member.name for member in tar.getmembers()]
-            self.assertIn('profiles/10.10.1.10/context', members)
+            self.assertIn('profiles/10.10.1.10/context.json', members)
             self.assertIn('profiles/{0}/{1}.10.10.1.10.profile'.format(
                 profiles.EXPORTED_KEYS_DIRNAME,
                 os.path.basename(key)), members)
@@ -141,7 +141,7 @@ class ProfilesTest(CliCommandTest):
             )
 
             self.assertTrue(os.path.isfile(
-                os.path.join(env.PROFILES_DIR, '10.10.1.10', 'context')))
+                os.path.join(env.PROFILES_DIR, '10.10.1.10', 'context.json')))
             self.assertTrue(os.path.isfile(key))
         finally:
             os.remove(key)

--- a/cloudify_cli/tests/commands/test_profiles.py
+++ b/cloudify_cli/tests/commands/test_profiles.py
@@ -70,9 +70,10 @@ class ProfilesTest(CliCommandTest):
 
     def test_delete_non_existing_profile(self):
         manager_ip = '10.10.1.10'
-        outcome = self.invoke('cfy profiles delete {0}'.format(manager_ip))
-        self.assertIn('Profile {0} does not exist'.format(manager_ip),
-                      outcome.logs)
+        self.invoke(
+            'cfy profiles delete {0}'.format(manager_ip),
+            err_str_segment='does not exist'
+        )
 
     def test_export_import_profiles(self):
         fd, profiles_archive = tempfile.mkstemp()

--- a/cloudify_cli/tests/commands/test_profiles.py
+++ b/cloudify_cli/tests/commands/test_profiles.py
@@ -106,7 +106,7 @@ class ProfilesTest(CliCommandTest):
         os.close(fd2)
         with open(key, 'w') as f:
             f.write('aaa')
-        self.use_manager(ssh_key_path=key)
+        self.use_manager(ssh_key=key)
         self.invoke('profiles list')
         try:
             self.invoke('cfy profiles export -o {0} --include-keys'.format(

--- a/cloudify_cli/tests/resources/profile.yaml
+++ b/cloudify_cli/tests/resources/profile.yaml
@@ -1,0 +1,29 @@
+# a more-or-less complete old-style yaml context, to be used in
+# old-context loading tests
+!CloudifyProfileContext
+_cluster: {}
+_profile_name: a
+_ssh_port: '22'
+kerberos_env: false
+manager_ip: 192.0.2.1
+manager_password: admin
+manager_tenant: default_tenant
+manager_username: admin
+provider_context:
+  cloudify:
+    cloudify_agent: {broker_port: 5671, heartbeat: 30, log_level: INFO, max_workers: 5,
+      min_workers: 2}
+    import_resolver:
+      parameters:
+        fallback: true
+        rules:
+        - {'http://www.getcloudify.org/spec': 'file:///opt/manager/resources/spec'}
+        - {'http://cloudify.co/spec': 'file:///opt/manager/resources/spec'}
+        - {'https://www.getcloudify.org/spec': 'file:///opt/manager/resources/spec'}
+        - {'https://cloudify.co/spec': 'file:///opt/manager/resources/spec'}
+    policy_engine: {start_timeout: 30}
+rest_certificate: null
+rest_port: 80
+rest_protocol: http
+ssh_key: null
+ssh_user: null

--- a/cloudify_cli/tests/test_env.py
+++ b/cloudify_cli/tests/test_env.py
@@ -113,7 +113,7 @@ class CliEnvTests(CliCommandTest):
     def _make_mock_profile(self, profile_name='10.10.1.10'):
         profile_path = os.path.join(env.PROFILES_DIR, profile_name)
         os.makedirs(profile_path)
-        with open(os.path.join(profile_path, 'context'), 'w') as profile:
+        with open(os.path.join(profile_path, 'context.json'), 'w') as profile:
             profile.write('nothing_for_now')
         return profile_path
 
@@ -1095,12 +1095,12 @@ class TestLocal(CliCommandTest):
     def test_storage_dir(self):
         self.assertEqual(
             cli_local.storage_dir(),
-            '/tmp/.cloudify-test/profiles/local'
+            os.path.join(env.PROFILES_DIR, 'local')
         )
 
         self.assertEqual(
             cli_local.storage_dir('blueprint_id'),
-            '/tmp/.cloudify-test/profiles/local/blueprint_id'
+            os.path.join(env.PROFILES_DIR, 'local', 'blueprint_id')
         )
 
     def test_initialize_blueprint_default_single_env(self):

--- a/cloudify_cli/tests/test_env.py
+++ b/cloudify_cli/tests/test_env.py
@@ -122,16 +122,6 @@ class CliEnvTests(CliCommandTest):
         env.delete_profile('10.10.1.10')
         self.assertFalse(os.path.isdir(profile_path))
 
-    def test_delete_non_existing_profile(self):
-        profile = 'non-existing-profile'
-        ex = self.assertRaises(
-            CloudifyCliError,
-            env.delete_profile,
-            profile_name=profile)
-        self.assertEqual(
-            'Profile {0} does not exist'.format(profile),
-            str(ex))
-
     def test_profile_exists(self):
         self.assertFalse(env.is_profile_exists('non-existing-profile'))
 
@@ -206,37 +196,16 @@ class CliEnvTests(CliCommandTest):
         self.assertTrue(hasattr(context, 'manager_ip'))
         self.assertEqual(context.manager_ip, '10.10.1.10')
 
-    def test_get_profile_context_for_local(self):
-        ex = self.assertRaises(
-            CloudifyCliError,
-            env.get_profile_context)
-        self.assertEqual('Local profile does not have context', str(ex))
-
     def test_get_context_path(self):
         profile = self.use_manager()
         context_path = env.get_context_path(profile.manager_ip)
         self.assertEqual(
             context_path,
-            os.path.join(env.PROFILES_DIR, '10.10.1.10', 'context'))
+            os.path.join(env.PROFILES_DIR, '10.10.1.10', 'context.json'))
 
     def test_fail_get_context_for_local_profile(self):
-        ex = self.assertRaises(
-            CloudifyCliError,
-            env.get_profile_context)
-        self.assertEqual('Local profile does not have context', str(ex))
-
-    def test_get_context_path_suppress_error(self):
-        profile = self.use_manager()
-        context_path = env.get_context_path(profile.manager_ip,
-                                            suppress_error=True)
-        self.assertEqual(
-            context_path,
-            os.path.join(env.PROFILES_DIR, '10.10.1.10', 'context'))
-
-    def test_fail_get_context_path_suppress_error(self):
-        context_path = env.get_context_path('not.existing.profile',
-                                            suppress_error=True)
-        self.assertIs(None, context_path)
+        with self.assertRaisesRegex(CloudifyCliError, 'No context'):
+            env.get_profile_context()
 
     def test_get_default_rest_cert_local_path(self):
         profile = self.use_manager()
@@ -254,12 +223,7 @@ class CliEnvTests(CliCommandTest):
 
     def test_fail_get_context_not_initialized(self):
         shutil.rmtree(env.CLOUDIFY_WORKDIR)
-        ex = self.assertRaises(
-            CloudifyCliError,
-            env.get_context_path,
-            'test'
-        )
-        self.assertEqual('Profile directory does not exist', str(ex))
+        self.assertIsNone(env.get_context_path('test'))
 
     def test_get_profile_dir(self):
         self.use_manager()
@@ -270,22 +234,7 @@ class CliEnvTests(CliCommandTest):
         self.assertTrue(os.path.isdir(profile_dir))
 
     def test_get_non_existing_profile_dir(self):
-        ex = self.assertRaises(
-            CloudifyCliError,
-            env.get_profile_dir)
-        self.assertEqual('Profile directory does not exist', str(ex))
-
-    def test_get_profile_dir_suppress_error(self):
-        self.use_manager()
-        profile_dir = env.get_profile_dir(suppress_error=True)
-        self.assertEqual(
-            profile_dir,
-            os.path.join(env.PROFILES_DIR, '10.10.1.10'))
-        self.assertTrue(os.path.isdir(profile_dir))
-
-    def test_get_non_existing_profile_dir_suppress_error(self):
-        profile_dir = env.get_profile_dir(suppress_error=True)
-        self.assertIs(None, profile_dir)
+        self.assertIsNone(env.get_profile_dir())
 
     def test_set_empty_profile_context(self):
         manager_ip = '10.10.1.10'


### PR DESCRIPTION
Instead of storing the profile as yaml, store it as json.

Still allow loading old yaml files.

Also some refactors around the profile methods.

See each commit for details