### PR TITLE
Load old profile yaml: support unicode tags

### DIFF
--- a/cloudify_cli/tests/resources/profile.yaml
+++ b/cloudify_cli/tests/resources/profile.yaml
@@ -6,7 +6,7 @@ _profile_name: a
 _ssh_port: '22'
 kerberos_env: false
 manager_ip: 192.0.2.1
-manager_password: admin
+manager_password: !!python/unicode admin
 manager_tenant: default_tenant
 manager_username: admin
 provider_context:


### PR DESCRIPTION
Support python/unicode because py2's yaml commonly generates those.

Still not gonna support the !CloudifyProfileContext via this,
because damn I'm not gonna rewrite yaml's whole dict parsing for this.