### PR TITLE
Update the .deb build to use py3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           path: test-results
   build-deb:
     docker:
-      - image: debian:9
+      - image: ubuntu:18.04
     steps:
       - checkout
       - run:
@@ -102,8 +102,8 @@ jobs:
           command: |
             set -ex
             apt-get update
-            apt-get install python python-setuptools -y
-            echo "export CLOUDIFY_VERSION=$(python ~/project/setup.py --version)" >>$BASH_ENV
+            apt-get install python3 python3-setuptools -y
+            echo "export CLOUDIFY_VERSION=$(python3 ~/project/setup.py --version)" >>$BASH_ENV
       - run:
           name: build the deb package
           command: /bin/bash ~/project/packaging/debian/build.sh

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
     timeout(time: 60, unit: 'MINUTES')
     timestamps()
   }
-  
+
   environment {
     PATH = "/root/.local/bin:$PATH"
     PROJECT = 'cloudify-cli'
@@ -115,7 +115,7 @@ pipeline {
               sh'''
                 set -ex
                 apt-get update
-                apt-get install python python-setuptools -y
+                apt-get install python3 python3-setuptools python3-distutils -y
               '''
               sh script: "/bin/bash ${env.WORKSPACE}/project/packaging/debian/build.sh", label: "build the deb package"
               sh script: """

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -36,7 +36,7 @@ spec:
       runAsUser: 0
       privileged: true
   - name: debbuild
-    image: debian:9
+    image: ubuntu:18.04
     command:
     - cat
     tty: true

--- a/packaging/debian/build.sh
+++ b/packaging/debian/build.sh
@@ -17,7 +17,7 @@ set -xu
 BUILD_DIR=~/cloudify-cli_${CLOUDIFY_VERSION}-${CLOUDIFY_PACKAGE_RELEASE}_amd64
 
 apt-get update
-apt-get install python python-virtualenv git -y
+apt-get install python3 python3-venv git -y
 mkdir -p "${BUILD_DIR}/DEBIAN" "${BUILD_DIR}/opt"
 cat >"${BUILD_DIR}/DEBIAN/control" <<EOF
 Package: cloudify
@@ -25,11 +25,11 @@ Version: ${CLOUDIFY_VERSION}
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: python (>= 2.7)
+Depends: python3 (<< 3.7), python3-distutils
 Maintainer: Cloudify Platform Ltd. <cosmo-admin@cloudify.co>
 Description: Cloudify's Command Line Interface
 EOF
-virtualenv /opt/cfy
+python3 -mvenv /opt/cfy
 /opt/cfy/bin/pip install -r "${PROJECT_DIR}/dev-requirements.txt"
 /opt/cfy/bin/pip install "${PROJECT_DIR}"
 cp /opt/cfy "${BUILD_DIR}/opt/cfy" -fr


### PR DESCRIPTION
Setting the build to ubuntu, because we can't support debian
(debian stretch is py3.5, debian buster is py3.7)