### PR TITLE
RD-1281 Fix prettify_client_error for py3

### DIFF
--- a/cloudify_cli/utils.py
+++ b/cloudify_cli/utils.py
@@ -294,7 +294,7 @@ def prettify_client_error(status_codes, logger):
     except CloudifyClientError as e:
         if e.status_code not in status_codes:
             raise
-        logger.info(e.message)
+        logger.error('Error: %s', e)
 
 
 def get_visibility(private_resource,


### PR DESCRIPTION
There's no .message, and it was deprecated in 2.6 anyway