### PR TITLE
RD-1352 Pin cryptography version before installing fabric

### DIFF
--- a/packaging/cloudify-cli.spec
+++ b/packaging/cloudify-cli.spec
@@ -23,6 +23,7 @@ Cloudify CLI
 
 %build
 python3 -m venv %_cli_env
+%_cli_env/bin/pip install --upgrade pip==20.3.4
 %_cli_env/bin/pip install -r "${RPM_SOURCE_DIR}/dev-requirements.txt"
 %_cli_env/bin/pip install "${RPM_SOURCE_DIR}"
 

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,7 @@
 #    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
-
 from setuptools import setup
-
 
 setup(
     name='cloudify',
@@ -51,6 +49,11 @@ setup(
         'backports.shutil_get_terminal_size==1.0.0',
         'ipaddress==1.0.23',
         'setuptools<=40.7.3',
+        'cryptography==3.3.2',
+        # Fabric depend on paramiko that depends on cryptography so we need
+        # to install the correct version of cryptography before installing
+        # the fabric so that fabric can be installed correctly in both py2 +
+        # py3
         'fabric==2.5.0'
     ]
 )


### PR DESCRIPTION
The reason why we introduced this changes is because of in our build the Centos/Redhat started to fail because of lower version of pip used inside the .spec file. On the other hand, the latest version that is supported by python 2 is cryptography==3.3.2 and any higher version cannot be work with python2.   The cryptography library is a dependency  for paramiko which is in turn a dependency for fabric version on cloudify cli. The following error raised:
```
[2021-02-08T00:25:22.473Z] Collecting paramiko>=2.4 (from fabric==2.5.0->cloudify==5.3.0.dev1)

[2021-02-08T00:25:22.473Z]   Downloading https://files.pythonhosted.org/packages/95/19/124e9287b43e6ff3ebb9cdea3e5e8e88475a873c05ccdf8b7e20d2c4201e/paramiko-2.7.2-py2.py3-none-any.whl (206kB)

[2021-02-08T00:25:22.735Z] Collecting invoke<2.0,>=1.3 (from fabric==2.5.0->cloudify==5.3.0.dev1)

[2021-02-08T00:25:22.735Z]   Downloading https://files.pythonhosted.org/packages/87/8f/c153d7db091f342da6bc97f7bedd1b2ce2867c4a8b0aab40fbba85a05e33/invoke-1.5.0-py3-none-any.whl (211kB)

[2021-02-08T00:25:22.735Z] Requirement already satisfied: monotonic>=0.1 in /opt/cfy/lib/python3.6/site-packages (from fasteners==0.13.0->cloudify-common[dispatcher]==5.3.0.dev1->cloudify==5.3.0.dev1)

[2021-02-08T00:25:22.735Z] Requirement already satisfied: decorator>=3.4.0 in /opt/cfy/lib/python3.6/site-packages (from networkx==1.9.1->cloudify-common[dispatcher]==5.3.0.dev1->cloudify==5.3.0.dev1)

[2021-02-08T00:25:22.735Z] Collecting pynacl>=1.0.1 (from paramiko>=2.4->fabric==2.5.0->cloudify==5.3.0.dev1)

[2021-02-08T00:25:22.997Z]   Downloading https://files.pythonhosted.org/packages/9d/57/2f5e6226a674b2bcb6db531e8b383079b678df5b10cdaa610d6cf20d77ba/PyNaCl-1.4.0-cp35-abi3-manylinux1_x86_64.whl (961kB)

[2021-02-08T00:25:22.997Z] Collecting cryptography>=2.5 (from paramiko>=2.4->fabric==2.5.0->cloudify==5.3.0.dev1)

[2021-02-08T00:25:23.590Z]   Downloading https://files.pythonhosted.org/packages/06/ed/cb79cc94ec58d9d92557238fc6c629cd6e07d72334d2de556aecc2211370/cryptography-3.4.1.tar.gz (544kB)

[2021-02-08T00:25:23.853Z]     Complete output from command python setup.py egg_info:

[2021-02-08T00:25:23.853Z]     

[2021-02-08T00:25:23.853Z]             =============================DEBUG ASSISTANCE==========================

[2021-02-08T00:25:23.853Z]             If you are seeing an error here please try the following to

[2021-02-08T00:25:23.853Z]             successfully install cryptography:

[2021-02-08T00:25:23.853Z]     

[2021-02-08T00:25:23.853Z]             Upgrade to the latest pip and try again. This will fix errors for most

[2021-02-08T00:25:23.853Z]             users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip

[2021-02-08T00:25:23.853Z]             =============================DEBUG ASSISTANCE==========================

[2021-02-08T00:25:23.853Z]     

[2021-02-08T00:25:23.853Z]     Traceback (most recent call last):

[2021-02-08T00:25:23.853Z]       File "<string>", line 1, in <module>

[2021-02-08T00:25:23.853Z]       File "/tmp/pip-build-k450wt_n/cryptography/setup.py", line 14, in <module>

[2021-02-08T00:25:23.853Z]         from setuptools_rust import RustExtension

[2021-02-08T00:25:23.853Z]     ModuleNotFoundError: No module named 'setuptools_rust'
```