### PR TITLE
RD-1458 Add filters to blueprints list

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1566,7 +1566,7 @@ class Options(object):
         )
 
         self.filter_rules = click.option(
-            '--filter',
+            '--filter', 'filter_rules',
             callback=parse_and_validate_filter_rules,
             help=helptexts.FILTER_RULES_OR_ID
         )

--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -241,6 +241,7 @@ def delete(blueprint_id, force, logger, client, tenant_name):
 @cfy.command(name='list', short_help='List blueprints')
 @cfy.options.sort_by()
 @cfy.options.descending
+@cfy.options.filter_rules
 @cfy.options.common_options
 @cfy.options.tenant_name_for_list(
     required=False, resource_name_for_help='blueprint')
@@ -253,6 +254,7 @@ def delete(blueprint_id, force, logger, client, tenant_name):
 @cfy.pass_logger
 def manager_list(sort_by,
                  descending,
+                 filter_rules,
                  tenant_name,
                  all_tenants,
                  search,
@@ -279,13 +281,21 @@ def manager_list(sort_by,
         _all_tenants=all_tenants,
         _search=search,
         _offset=pagination_offset,
-        _size=pagination_size
+        _size=pagination_size,
+        filter_rules=filter_rules
     )
     blueprints = [trim_description(b) for b in blueprints_list]
     modify_resource_labels(blueprints)
     print_data(BLUEPRINT_COLUMNS, blueprints, 'Blueprints:')
+
     total = blueprints_list.metadata.pagination.total
-    logger.info('Showing {0} of {1} blueprints'.format(len(blueprints), total))
+    base_str = 'Showing {0} of {1} blueprints'.format(
+        len(blueprints_list), total)
+    if filter_rules:
+        filtered = blueprints_list.metadata.get('filtered')
+        if filtered is not None:
+            base_str += ' ({} hidden by filter)'.format(filtered)
+    logger.info(base_str)
 
 
 @cfy.command(name='list', short_help='List blueprints')

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -191,7 +191,7 @@ def _print_single_update(deployment_update_dict,
 @cfy.pass_logger
 def manager_list(blueprint_id,
                  group_id,
-                 filter,
+                 filter_rules,
                  sort_by,
                  descending,
                  all_tenants,
@@ -215,7 +215,7 @@ def manager_list(blueprint_id,
 
     deployments = client.deployments.list(sort=sort_by,
                                           is_descending=descending,
-                                          filter_rules=filter,
+                                          filter_rules=filter_rules,
                                           _all_tenants=all_tenants,
                                           _search=search,
                                           _offset=pagination_offset,
@@ -227,7 +227,7 @@ def manager_list(blueprint_id,
     print_data(DEPLOYMENT_COLUMNS, deployments, 'Deployments:')
 
     base_str = 'Showing {0} of {1} deployments'.format(len(deployments), total)
-    if filter:
+    if filter_rules:
         filtered = deployments.metadata.get('filtered')
         if filtered is not None:
             base_str += ' ({} hidden by filter)'.format(filtered)

--- a/cloudify_cli/tests/commands/test_blueprints.py
+++ b/cloudify_cli/tests/commands/test_blueprints.py
@@ -528,3 +528,18 @@ class BlueprintsTest(CliCommandTest):
         self.invoke('cfy blueprints labels delete key2 bp1')
         call_args = list(self.client.blueprints.update.call_args)
         self.assertEqual(call_args[0][1]['labels'], [{'key1': 'val1'}])
+
+    def test_blueprints_list_with_filters(self):
+        self.client.blueprints.list = MagicMock(
+            return_value=MockListResponse()
+        )
+        self.invoke('cfy blueprints list --filter filter')
+        self.invoke('cfy blueprints list --filter "a=b and c!=[d,f]"')
+
+    def test_blueprints_list_with_invalid_filters(self):
+        self.invoke('cfy blueprints list --filter a%d',
+                    err_str_segment='The filter ID contains illegal',
+                    exception=CloudifyValidationError)
+        self.invoke('cfy blueprints list --filter "a=b and e is nu"',
+                    err_str_segment='Filter rules must be one of',
+                    exception=CloudifyValidationError)


### PR DESCRIPTION
This PR adds filters to blueprints list.
The `filter` parameter was changed to `filter_rules` so it won't shadow the built-in name `filter`.