### PR TITLE
CYBL-1107-Automatically fix inputs' types

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1411,6 +1411,13 @@ class Options(object):
             required=False,
             help=helptexts.RUNTIME_ONLY_EVALUATION)
 
+        self.auto_correct_types = click.option(
+            '--auto-correct-types',
+            is_flag=True,
+            default=False,
+            required=False,
+            help=helptexts.AUTO_CORRECT_TYPES)
+
         self.manager = click.option(
             '--manager',
             required=False,

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -390,6 +390,9 @@ RUNTIME_ONLY_EVALUATION = "If set, all intrinsic functions will only be "\
                           "evaluated at runtime, and no intrinsic functions "\
                           "will be evaluated at parse time (such as "\
                           "get_input, get_property)"
+AUTO_CORRECT_TYPES = "If set, before creating plan for a new deployment, an "\
+                     "attempt will be made to cast old inputs' values to "\
+                     "the valid types declared in blueprint"
 MANAGER = "Connect to a specific manager by IP or host"
 
 FROM_DATETIME = "Beginning of a period"

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -305,6 +305,7 @@ def manager_get_update(deployment_update_id, logger, client, tenant_name):
 @cfy.options.json_output
 @cfy.options.common_options
 @cfy.options.runtime_only_evaluation
+@cfy.options.auto_correct_types
 @cfy.assert_manager_active()
 @cfy.pass_client()
 @cfy.pass_logger
@@ -332,7 +333,8 @@ def manager_update(ctx,
                    blueprint_id,
                    visibility,
                    validate,
-                   runtime_only_evaluation):
+                   runtime_only_evaluation,
+                   auto_correct_types):
     """Update a specified deployment according to the specified blueprint.
     The blueprint can be supplied as an id of a blueprint that already exists
     in the system (recommended).
@@ -409,7 +411,8 @@ def manager_update(ctx,
             reinstall_list,
             preview,
             not dont_update_plugins,
-            runtime_only_evaluation=runtime_only_evaluation
+            runtime_only_evaluation=runtime_only_evaluation,
+            auto_correct_types=auto_correct_types,
         )
 
     if preview:

--- a/cloudify_cli/tests/commands/test_deployments.py
+++ b/cloudify_cli/tests/commands/test_deployments.py
@@ -299,6 +299,12 @@ class DeploymentUpdatesTest(CliCommandTest):
                             'new blueprint), or new inputs',
             exception=CloudifyCliError)
 
+    def test_deployment_update_inputs_correct(self):
+        self.invoke(
+            'cfy deployments update -p '
+            '{0} -i {1} my_deployment --auto-correct-types'
+            .format(SAMPLE_ARCHIVE_PATH, SAMPLE_INPUTS_PATH))
+
 
 class DeploymentsTest(CliCommandTest):
 


### PR DESCRIPTION
* Add --auto-correct-types to deployments update

The flag can be used to trigger inputs type casting functionality
(a.k.a. inputs auto-correction) in the dsl_parser.