### PR TITLE
RD-1515 Add --auto-correct-types to plugins update

### DIFF
--- a/cloudify_cli/commands/plugins.py
+++ b/cloudify_cli/commands/plugins.py
@@ -461,6 +461,7 @@ def set_visibility(plugin_id, visibility, logger, client):
 @cfy.pass_logger
 @cfy.pass_client()
 @cfy.options.force(help=helptexts.FORCE_PLUGINS_UPDATE)
+@cfy.options.auto_correct_types
 def update(blueprint_id,
            all_blueprints,
            plugin_names,
@@ -473,7 +474,8 @@ def update(blueprint_id,
            logger,
            client,
            tenant_name,
-           force):
+           force,
+           auto_correct_types):
     """Update the plugins of all the deployments of the given blueprint
     or any blueprint in case `--all` flag was used instead of providing
     a BLUEPRINT_ID.  This will update the deployments one by one until
@@ -521,7 +523,7 @@ def update(blueprint_id,
         _update_a_blueprint(blueprint_id, plugin_names,
                             to_latest, all_to_latest, to_minor, all_to_minor,
                             include_logs, json_output, logger,
-                            client, force)
+                            client, force, auto_correct_types)
     elif all_blueprints:
         update_results = {'successful': [], 'failed': []}
         pagination_offset = 0
@@ -536,7 +538,7 @@ def update(blueprint_id,
                                         to_latest, all_to_latest,
                                         to_minor, all_to_minor,
                                         include_logs, json_output, logger,
-                                        client, force)
+                                        client, force, auto_correct_types)
                     update_results['successful'].append(blueprint.id)
                 except CloudifyClientError as ex:
                     update_results['failed'].append(blueprint.id)
@@ -566,13 +568,15 @@ def _update_a_blueprint(blueprint_id,
                         json_output,
                         logger,
                         client,
-                        force):
+                        force,
+                        auto_correct_types):
     logger.info('Updating the plugins of the deployments of the blueprint '
                 '{}'.format(blueprint_id))
     plugins_update = client.plugins_update.update_plugins(
         blueprint_id, force=force, plugin_names=plugin_names,
         to_latest=to_latest, all_to_latest=all_to_latest,
-        to_minor=to_minor, all_to_minor=all_to_minor
+        to_minor=to_minor, all_to_minor=all_to_minor,
+        auto_correct_types=auto_correct_types,
     )
     events_logger = get_events_logger(json_output)
     execution = execution_events_fetcher.wait_for_execution(

--- a/cloudify_cli/tests/commands/test_plugins.py
+++ b/cloudify_cli/tests/commands/test_plugins.py
@@ -459,10 +459,12 @@ class PluginsUpdateTest(CliCommandTest):
             list(update_client_mock.call_args_list),
             [call('asdf', force=False, plugin_names=[],
                   to_latest=[], all_to_latest=True,
-                  to_minor=[], all_to_minor=False),
+                  to_minor=[], all_to_minor=False,
+                  auto_correct_types=False),
              call('zxcv', force=False, plugin_names=[],
                   to_latest=[], all_to_latest=True,
-                  to_minor=[], all_to_minor=False)])
+                  to_minor=[], all_to_minor=False,
+                  auto_correct_types=False)])
 
     def test_params_plugin_name_syntax_error(self):
         update_client_mock = Mock()
@@ -557,6 +559,29 @@ class PluginsUpdateTest(CliCommandTest):
                           self.invoke,
                           'cfy plugins update '
                           '--all-to-latest --all-to-minor asdf')
+
+    def test_params_auto_correct_types(self):
+        update_plugin_name = 'plugin-name'
+        update_client_mock = Mock()
+        self.client.plugins_update.update_plugins = update_client_mock
+        self.invoke('cfy plugins update --plugin-name {0} '
+                    '--auto-correct-types asdf'.format(
+                        update_plugin_name))
+
+        auto_correct_types = self._inspect_calls(update_client_mock,
+                                                 'auto_correct_types')
+        self.assertTrue(auto_correct_types)
+
+    def test_params_not_auto_correct_types(self):
+        update_plugin_name = 'plugin-name'
+        update_client_mock = Mock()
+        self.client.plugins_update.update_plugins = update_client_mock
+        self.invoke('cfy plugins update --plugin-name {0} asdf'.format(
+            update_plugin_name))
+
+        auto_correct_types = self._inspect_calls(update_client_mock,
+                                                 'auto_correct_types')
+        self.assertFalse(auto_correct_types)
 
 
 class TestFormatInstallationState(unittest.TestCase):


### PR DESCRIPTION
* Add --auto-correct-types to plugins update

* Fix PluginsUpdateTest.test_all test

This is a cherry-pick of https://github.com/cloudify-cosmo/cloudify-cli/pull/1220 to the 5.1.3-build branch