### PR TITLE
RD-1482 Add deployment state to the deployment table info

### DIFF
--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -62,7 +62,8 @@ from .summary import BASE_SUMMARY_FIELDS, structure_summary_results
 
 DEPLOYMENT_COLUMNS = [
     'id', 'blueprint_id', 'created_at', 'updated_at', 'visibility',
-    'tenant_name', 'created_by', 'site_name', 'labels'
+    'tenant_name', 'created_by', 'site_name', 'labels',
+    'deployment_status', 'installation_status'
 ]
 DEPLOYMENT_UPDATE_COLUMNS = [
     'id', 'deployment_id', 'tenant_name', 'state', 'execution_id',


### PR DESCRIPTION
This PR created in order to expose the following deployment statuses: `installation_status` && `deployment_status` in the deployment table on the cli