### PR TITLE
RD-1638 Exclude blueprints from plugins update

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1524,6 +1524,14 @@ class Options(object):
             default=False,
             help=helptexts.PLUGINS_UPDATE_ALL)
 
+        self.except_blueprints = click.option(
+            '--except-blueprint',
+            'except_blueprints',
+            multiple=True,
+            required=False,
+            help=helptexts.PLUGINS_UPDATE_EXCEPT_BLUEPRINT,
+            callback=self.parse_comma_separated)
+
         self.plugin_names = click.option(
             '--plugin-name',
             'plugin_names',

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -464,17 +464,21 @@ STORE_OUTPUT_PATH = "Store listed events to a specified file (cli side)"
 
 PLUGINS_UPDATE_ALL = "Iterate through all blueprints of the current tenant "\
                      "and update all used plugins"
+PLUGINS_UPDATE_EXCEPT_BLUEPRINT = "List of blueprint IDs to be excluded "\
+                                  "from all blueprints update (can be passed "\
+                                  "multiple times or take comma separated "\
+                                  "values)"
 PLUGINS_UPDATE_NAME = "Update only the specific plugin in all selected "\
                       "deployments (can be passed multiple times or take "\
                       "comma separated values)"
 PLUGINS_UPDATE_TO_LATEST = "List of plugin names to be upgraded to the "\
                            "latest version (can be passed multiple times "\
-                           "or take comma separated values"
+                           "or take comma separated values)"
 PLUGINS_UPDATE_ALL_TO_LATEST = "Update all (selected) plugins to the latest "\
                                "version of a plugin"
 PLUGINS_UPDATE__TO_MINOR = "List of plugin names to be upgraded to the "\
                            "latest minor version (can be passed multiple "\
-                           "times or take comma separated values"
+                           "times or take comma separated values)"
 PLUGINS_UPDATE_ALL_TO_MINOR = "Update all (selected) plugins to the latest "\
                               "minor version"
 REEVALUATE_ACTIVE_STATUSES = "If set, before attempting to update plugins, " \

--- a/cloudify_cli/commands/plugins.py
+++ b/cloudify_cli/commands/plugins.py
@@ -448,6 +448,7 @@ def set_visibility(plugin_id, visibility, logger, client):
                             'the blueprint [manager only]')
 @cfy.argument('blueprint-id', required=False)
 @cfy.options.all_blueprints
+@cfy.options.except_blueprints
 @cfy.options.plugin_names
 @cfy.options.plugins_to_latest
 @cfy.options.plugins_all_to_latest
@@ -465,6 +466,7 @@ def set_visibility(plugin_id, visibility, logger, client):
 @cfy.options.reevaluate_active_statuses
 def update(blueprint_id,
            all_blueprints,
+           except_blueprints,
            plugin_names,
            to_latest,
            all_to_latest,
@@ -501,6 +503,10 @@ def update(blueprint_id,
         raise CloudifyValidationError(
             'ERROR: Invalid command syntax. Either provide '
             'a BLUEPRINT_ID or use --all flag.')
+    if except_blueprints and not all_blueprints:
+        raise CloudifyValidationError(
+            'ERROR: Invalid command syntax. Cannot list blueprints '
+            'exceptions unless used with --all flag.')
     all_to_minor = bool(all_to_minor)
     if all_to_latest is None:
         all_to_latest = not all_to_minor
@@ -536,6 +542,8 @@ def update(blueprint_id,
                 _offset=pagination_offset,
             )
             for blueprint in blueprints:
+                if blueprint.id in except_blueprints:
+                    continue
                 try:
                     _update_a_blueprint(blueprint.id, plugin_names,
                                         to_latest, all_to_latest,


### PR DESCRIPTION
Add `--exclude-blueprint` parameter to the `cfy plugins update --all` command.  It's purpose is to skip update of specified blueprint(s).