### PR TITLE
CYBL-1114 reevaluate plugin and deployment update statuses

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1418,6 +1418,13 @@ class Options(object):
             required=False,
             help=helptexts.AUTO_CORRECT_TYPES)
 
+        self.reevaluate_active_statuses = click.option(
+            '--reevaluate-active-statuses',
+            is_flag=True,
+            default=False,
+            required=False,
+            help=helptexts.REEVALUATE_ACTIVE_STATUSES)
+
         self.manager = click.option(
             '--manager',
             required=False,

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -418,5 +418,15 @@ PLUGINS_UPDATE__TO_MINOR = "List of plugin names to be upgraded to the "\
                            "times or take comma separated values"
 PLUGINS_UPDATE_ALL_TO_MINOR = "Update all (selected) plugins to the latest "\
                               "minor version"
+REEVALUATE_ACTIVE_STATUSES = "If set, before attempting to update plugins, " \
+                             "the statuses of previous active plugins " \
+                             "updates operations will be reevaluated based " \
+                             "on relevant executions' statuses. " \
+                             "`terminated` executions will be mapped to " \
+                             "`successful` plugins updates, while `failed` " \
+                             "and any `*cancel*` statuses will be mapped to " \
+                             "`failed`.  This flag is also passed down to " \
+                             "the deployment update flows and has a similar " \
+                             "effect on those."
 
 LABELS = "A labels list of the form <key>:<value>,<key>:<value>"

--- a/cloudify_cli/commands/plugins.py
+++ b/cloudify_cli/commands/plugins.py
@@ -462,6 +462,7 @@ def set_visibility(plugin_id, visibility, logger, client):
 @cfy.pass_client()
 @cfy.options.force(help=helptexts.FORCE_PLUGINS_UPDATE)
 @cfy.options.auto_correct_types
+@cfy.options.reevaluate_active_statuses
 def update(blueprint_id,
            all_blueprints,
            plugin_names,
@@ -475,7 +476,8 @@ def update(blueprint_id,
            client,
            tenant_name,
            force,
-           auto_correct_types):
+           auto_correct_types,
+           reevaluate_active_statuses):
     """Update the plugins of all the deployments of the given blueprint
     or any blueprint in case `--all` flag was used instead of providing
     a BLUEPRINT_ID.  This will update the deployments one by one until
@@ -523,7 +525,8 @@ def update(blueprint_id,
         _update_a_blueprint(blueprint_id, plugin_names,
                             to_latest, all_to_latest, to_minor, all_to_minor,
                             include_logs, json_output, logger,
-                            client, force, auto_correct_types)
+                            client, force, auto_correct_types,
+                            reevaluate_active_statuses)
     elif all_blueprints:
         update_results = {'successful': [], 'failed': []}
         pagination_offset = 0
@@ -538,7 +541,8 @@ def update(blueprint_id,
                                         to_latest, all_to_latest,
                                         to_minor, all_to_minor,
                                         include_logs, json_output, logger,
-                                        client, force, auto_correct_types)
+                                        client, force, auto_correct_types,
+                                        reevaluate_active_statuses)
                     update_results['successful'].append(blueprint.id)
                 except CloudifyClientError as ex:
                     update_results['failed'].append(blueprint.id)
@@ -569,7 +573,8 @@ def _update_a_blueprint(blueprint_id,
                         logger,
                         client,
                         force,
-                        auto_correct_types):
+                        auto_correct_types,
+                        reevaluate_active_statuses):
     logger.info('Updating the plugins of the deployments of the blueprint '
                 '{}'.format(blueprint_id))
     plugins_update = client.plugins_update.update_plugins(
@@ -577,6 +582,7 @@ def _update_a_blueprint(blueprint_id,
         to_latest=to_latest, all_to_latest=all_to_latest,
         to_minor=to_minor, all_to_minor=all_to_minor,
         auto_correct_types=auto_correct_types,
+        reevaluate_active_statuses=reevaluate_active_statuses,
     )
     events_logger = get_events_logger(json_output)
     execution = execution_events_fetcher.wait_for_execution(

--- a/cloudify_cli/tests/commands/test_plugins.py
+++ b/cloudify_cli/tests/commands/test_plugins.py
@@ -460,11 +460,13 @@ class PluginsUpdateTest(CliCommandTest):
             [call('asdf', force=False, plugin_names=[],
                   to_latest=[], all_to_latest=True,
                   to_minor=[], all_to_minor=False,
-                  auto_correct_types=False),
+                  auto_correct_types=False,
+                  reevaluate_active_statuses=False),
              call('zxcv', force=False, plugin_names=[],
                   to_latest=[], all_to_latest=True,
                   to_minor=[], all_to_minor=False,
-                  auto_correct_types=False)])
+                  auto_correct_types=False,
+                  reevaluate_active_statuses=False)])
 
     def test_params_plugin_name_syntax_error(self):
         update_client_mock = Mock()


### PR DESCRIPTION
* New flags for status reevaluation of plugins update

`-reevaluate-active-statuses` flag added to `cfy plugins update` command.
It's purpuse is to map the executions' statuses to plugin updates'
statuses before performing plugins update procedure.  `failed` and any
`*cancel*` statuses of the executions will be mapped to `failed` statuses
of the plugin updates, while `terminated` - to `successful`.

* Fix PluginsUpdateTest.test_all()

* Update helptext for reevaluate-active-status flag