### PR TITLE
RD-937 Add license validation wrapper to upload commands

### DIFF
--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -99,6 +99,7 @@ def validate_blueprint(blueprint_path, logger):
 @cfy.pass_client()
 @cfy.pass_logger
 @cfy.pass_context
+@utils.verify_active_license
 def upload(ctx,
            blueprint_path,
            blueprint_id,

--- a/cloudify_cli/commands/plugins.py
+++ b/cloudify_cli/commands/plugins.py
@@ -111,6 +111,7 @@ def delete(plugin_id, force, logger, client, tenant_name):
 @cfy.assert_manager_active()
 @cfy.pass_client()
 @cfy.pass_logger
+@utils.verify_active_license
 def upload(ctx,
            plugin_path,
            yaml_path,
@@ -163,6 +164,7 @@ def upload(ctx,
 @cfy.options.plugins_bundle_path
 @cfy.pass_client()
 @cfy.pass_logger
+@utils.verify_active_license
 def upload_caravan(client, logger, path):
     if not path:
         logger.info("Starting upload of plugins bundle, "

--- a/cloudify_cli/commands/snapshots.py
+++ b/cloudify_cli/commands/snapshots.py
@@ -158,6 +158,7 @@ def delete(snapshot_id, logger, client, tenant_name):
 @cfy.options.tenant_name(required=False, resource_name_for_help='snapshot')
 @cfy.pass_client()
 @cfy.pass_logger
+@utils.verify_active_license
 def upload(snapshot_path,
            snapshot_id,
            logger,

--- a/cloudify_cli/tests/commands/test_blueprints.py
+++ b/cloudify_cli/tests/commands/test_blueprints.py
@@ -59,6 +59,7 @@ class BlueprintsTest(CliCommandTest):
 
     def setUp(self):
         super(BlueprintsTest, self).setUp()
+        self.client.license.list = Mock(return_value=[{'expired': False}])
         self.use_manager()
         self._mock_wait_for_blueprint_upload(False)
 

--- a/cloudify_cli/tests/commands/test_deployments.py
+++ b/cloudify_cli/tests/commands/test_deployments.py
@@ -73,6 +73,7 @@ class DeploymentUpdatesTest(CliCommandTest):
 
     def setUp(self):
         super(DeploymentUpdatesTest, self).setUp()
+        self.client.license.list = Mock(return_value=[{'expired': False}])
         self.use_manager()
 
         self.client.deployment_updates.update = MagicMock()

--- a/cloudify_cli/tests/commands/test_plugins.py
+++ b/cloudify_cli/tests/commands/test_plugins.py
@@ -53,6 +53,7 @@ class PluginsTest(CliCommandTest):
 
     def setUp(self):
         super(PluginsTest, self).setUp()
+        self.client.license.list = Mock(return_value=[{'expired': False}])
         self.use_manager()
 
     def test_plugins_list(self):

--- a/cloudify_cli/tests/commands/test_snapshots.py
+++ b/cloudify_cli/tests/commands/test_snapshots.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from mock import Mock, MagicMock
 
 from .mocks import MockListResponse
 from .constants import SNAPSHOTS_DIR
@@ -11,6 +11,7 @@ class SnapshotsTest(CliCommandTest):
 
     def setUp(self):
         super(SnapshotsTest, self).setUp()
+        self.client.license.list = Mock(return_value=[{'expired': False}])
         self.use_manager()
 
     def test_snapshots_list(self):

--- a/cloudify_cli/utils.py
+++ b/cloudify_cli/utils.py
@@ -468,3 +468,24 @@ def wait_for_blueprint_upload(client, blueprint_id, logging_level):
 
     _handle_errors()
     return blueprint
+
+
+def verify_active_license(func):
+    """
+    :param func: a CLI command function.
+    This decorator assumes a client was passed to the function,
+    thus should be placed below a @cfy.pass_client() decorator.
+    """
+    def wrapper(*args, **kwargs):
+        for cfy_license in kwargs['client'].license.list():
+            if not cfy_license['expired']:
+                return func(*args, **kwargs)
+
+        error_message = 'ERROR: No active license. To activate this product,' \
+                        ' please upload a valid license using the' \
+                        ' `cfy license upload` command. If you do not' \
+                        ' have a license, please visit the Cloudify' \
+                        ' website at https://cloudify.co/download/#trial' \
+                        ' to learn more and acquire a free trial license.'
+        raise CloudifyCliError(error_message)
+    return wrapper


### PR DESCRIPTION
Currently, license validation happens only on the REST server. So when a user without an active license uploads a big file (blueprint, plugin, snapshot), then only after it has been uploaded (which takes a while) they get a message that there is no active license, and the operation fails. 
We'd like to spare users the wait by checking for an active license before upload commands are executed in the CLI.