### PR TITLE
RD-1603 Exec-schedules: split weekdays

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1622,7 +1622,9 @@ class Options(object):
             cls=MutuallyExclusiveOption,
             mutually_exclusive=['rrule'],
             required=False,
-            help=helptexts.SCHEDULE_WEEKDAYS
+            help=helptexts.SCHEDULE_WEEKDAYS,
+            multiple=True,
+            callback=self.parse_comma_separated,
         )
 
         self.rrule = click.option(


### PR DESCRIPTION
Parse the weekdays string when it is given by the user, in an option
callback. Then we can use structured data inside, instead of passing
just a string around.

cloudify-cosmo/cloudify-common#727 is the restclient side of this.

As a nice bonus, now you can do `--weekdays fr --weekdays su,mo` and
it will all be added together