### PR TITLE
RD-1693 Allow special chars in labels

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -26,7 +26,9 @@ from ..inputs import inputs_to_dict
 from ..utils import generate_random_string
 from ..constants import DEFAULT_BLUEPRINT_PATH
 from ..exceptions import SuppressedCloudifyCliError
-from ..exceptions import CloudifyBootstrapError, CloudifyValidationError
+from ..exceptions import (LabelsValidationError,
+                          CloudifyBootstrapError,
+                          CloudifyValidationError,)
 from ..logger import (
     get_logger,
     set_global_verbosity_level,
@@ -233,19 +235,7 @@ def parse_and_validate_labels(ctx, param, value):
         raise CloudifyValidationError(
             'ERROR: The `{0}` argument is empty'.format(param.name))
 
-    labels_list = []
-    raw_labels_list = value.split(',')
-    for label in raw_labels_list:
-        if label.count(':') != 1:
-            raise CloudifyValidationError('ERROR: Labels should be of the '
-                                          'form <key>:<value>,<key>:<value>')
-
-        label_key, label_value = label.split(':')
-        validate_param_value('The key of one or more labels', label_key)
-        validate_param_value('The value of one or more labels', label_value)
-        labels_list.append({label_key: label_value})
-
-    return labels_list
+    return get_formatted_labels_list(value)
 
 
 def parse_and_validate_label_to_delete(ctx, param, value):
@@ -256,40 +246,77 @@ def parse_and_validate_label_to_delete(ctx, param, value):
         raise CloudifyValidationError(
             'ERROR: The `{0}` argument is empty'.format(param.name))
 
-    if ',' in value or value.count(':') > 1:
+    labels_list = get_formatted_labels_list(value, allow_only_key=True)
+    if len(labels_list) > 1:
         raise CloudifyValidationError(
             'LABEL can be either <key>:<value> or <key>')
-
-    label = value.split(':')
-    if len(label) == 1:
-        validate_param_value('The provided key', label[0])
-        return label[0]
-    else:
-        label_key, label_value = label
-        validate_param_value('The key of the provided label', label_key)
-        validate_param_value('The value of the provided label', label_value)
-        return {label_key: label_value}
+    [(label_key, label_value)] = labels_list[0].items()
+    if label_value:
+        return labels_list[0]
+    return label_key
 
 
-def parse_labels_filter_rules(ctx, param, value):
-    if value is None or ctx.resilient_parsing:
+def get_formatted_labels_list(raw_labels_list, allow_only_key=False):
+    labels_list = []
+    if '\x00' in raw_labels_list:
+        raise CloudifyValidationError('Error: labels cannot contain null')
+    format_err_msg = 'Labels should be of the form <key>:<value>,<key>:<value>'
+    raw_labels_list = raw_labels_list.replace('\\,', '\x00').split(',')
+    for label in raw_labels_list:
+        label = label.replace('\x00', ',')
+        label = label.replace('\\:', '\x00')
+        colons_count = label.count(':')
+        if colons_count == 0:
+            if not allow_only_key:
+                raise LabelsValidationError(label, format_err_msg)
+            label_key, label_value = label, None
+
+        elif colons_count == 1:
+            label_key, label_value = label.split(':')
+            if not label_key or not label_value:
+                raise LabelsValidationError(label, format_err_msg)
+            label_value = label_value.replace('\x00', ':')
+            if any(char in label_value for char in ['"', '\n', '\t']):
+                raise LabelsValidationError(
+                    label_value,
+                    "The label's value contains one of `\"`, `\\n`, `\\t`")
+
+        else:
+            if allow_only_key:
+                raise CloudifyValidationError(
+                    'LABEL can be either <key>:<value> or <key>')
+            raise LabelsValidationError(label, format_err_msg)
+
+        label_key = label_key.replace('\x00', ':').strip()
+        try:
+            validate_param_value('label_key', label_key)
+        except CloudifyValidationError:
+            raise LabelsValidationError(
+                label, "The label's key contains illegal characters. "
+                       "Only letters, digits and the characters `-`, `.` and "
+                       "`_` are allowed")
+
+        labels_list.append({label_key: label_value})
+
+    return labels_list
+
+
+def _validate_filter_rules_not_empty(ctx, param, value):
+    if value is None or value == () or ctx.resilient_parsing:
         return
 
     if not value:
         raise CloudifyValidationError(
             'ERROR: The `{0}` argument is empty'.format(param.name))
 
+
+def parse_labels_filter_rules(ctx, param, value):
+    _validate_filter_rules_not_empty(ctx, param, value)
     return create_labels_filter_rules_list(value)
 
 
 def parse_attributes_filter_rules(ctx, param, value):
-    if value is None or ctx.resilient_parsing:
-        return
-
-    if not value:
-        raise CloudifyValidationError(
-            'ERROR: The `{0}` argument is empty'.format(param.name))
-
+    _validate_filter_rules_not_empty(ctx, param, value)
     return create_attributes_filter_rules_list(value)
 
 
@@ -1683,6 +1710,12 @@ class Options(object):
             help=helptexts.GROUP_ID_FILTER,
         )
 
+        self.filter_id = click.option(
+            '--filter-id',
+            callback=validate_name,
+            help=helptexts.FILTER_ID
+        )
+
     def common_options(self, f):
         """A shorthand for applying commonly used arguments.
 
@@ -2177,83 +2210,38 @@ class Options(object):
             help=help)
 
     @staticmethod
-    def _resource_filter_methods(f, resource):
-        help_text = (helptexts.DEPLOYMENTS_ATTRS_FILTER_RULES if
-                     resource == 'deployment' else
-                     helptexts.BLUEPRINTS_ATTRS_FILTER_RULES)
-        filter_id = click.option(
-            '--filter-id',
-            callback=validate_name,
-            help=helptexts.FILTER_ID
-        )
-
-        labels_filter = click.option(
-            '--labels-filter',
-            callback=parse_labels_filter_rules,
-            help=helptexts.LABELS_FILTER_RULES
-        )
-
-        attrs_filter = click.option(
-           '--attrs-filter',
-           callback=parse_attributes_filter_rules,
-           help=help_text
-        )
-
-        def _resource_filter_methods_deco(f):
-            @wraps(f)
-            def _inner(*args, **kwargs):
-                filter_methods = {}
-                filter_rules = get_filter_rules(
-                    kwargs.pop('labels_filter', None),
-                    kwargs.pop('attrs_filter', None))
-                filter_methods['filter_id'] = kwargs.pop('filter_id', None)
-                filter_methods['filter_rules'] = filter_rules
-
-                kwargs['resource_filter_methods'] = filter_methods
-                return f(*args, **kwargs)
-            return _inner
-
-        for arg in [attrs_filter, labels_filter, filter_id,
-                    _resource_filter_methods_deco]:
-            f = arg(f)
-
-        return f
-
-    def blueprint_filter_methods(self, f):
-        return self._resource_filter_methods(f, 'blueprint')
-
-    def deployment_filter_methods(self, f):
-        return self._resource_filter_methods(f, 'deployment')
-
-    @staticmethod
     def _filter_rules(f, resource):
         help_text = (helptexts.DEPLOYMENTS_ATTRS_FILTER_RULES if
                      resource == 'deployment' else
                      helptexts.BLUEPRINTS_ATTRS_FILTER_RULES)
-        attrs_rules = click.option(
-            '--attrs-rules',
+        attrs_rule = click.option(
+            '-ar',
+            '--attrs-rule',
             callback=parse_attributes_filter_rules,
-            help=help_text
+            help=help_text,
+            multiple=True
         )
 
-        labels_rules = click.option(
-            '--labels-rules',
+        labels_rule = click.option(
+            '-lr',
+            '--labels-rule',
             callback=parse_labels_filter_rules,
-            help=helptexts.LABELS_FILTER_RULES
+            help=helptexts.LABELS_FILTER_RULES,
+            multiple=True
         )
 
         def _filter_rules_deco(f):
             @wraps(f)
             def _inner(*args, **kwargs):
                 filter_rules = get_filter_rules(
-                    kwargs.pop('labels_rules', None),
-                    kwargs.pop('attrs_rules', None))
+                    kwargs.pop('labels_rule', None),
+                    kwargs.pop('attrs_rule', None))
 
                 kwargs['filter_rules'] = filter_rules
                 return f(*args, **kwargs)
             return _inner
 
-        for arg in [attrs_rules, labels_rules, _filter_rules_deco]:
+        for arg in [attrs_rule, labels_rule, _filter_rules_deco]:
             f = arg(f)
 
         return f

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -506,9 +506,9 @@ LABELS_FILTER_RULES = "A labels' filter rule. Labels' filter rules must be " \
                       "one of: <key>=<value>, <key>!=<value>, <key> is null," \
                       " <key> is not null. <value> can be a single string " \
                       "or a list of strings of the form " \
-                      "[<value1>,<value2>,...]. Any comma in <value> must " \
-                      "be escaped with `\\`. The labels' filter rules " \
-                      "will be saved in lower case."
+                      "[<value1>,<value2>,...]. Any comma and colon in " \
+                      "<value> must be escaped with `\\`. The labels' " \
+                      "filter rules will be saved in lower case."
 
 ATTRS_FILTER_RULES = "An attributes' filter rule. Attributes' filter rules " \
                      "must be one of:  <key>=<value>, <key>!=<value>, " \

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -499,21 +499,21 @@ REEVALUATE_ACTIVE_STATUSES_PLUGINS = REEVALUATE_ACTIVE_STATUSES + "  This " \
                                      "deployment update flows and has " \
                                      "a similar effect on those."
 
-LABELS = "A labels list of the form <key>:<value>,<key>:<value>"
+LABELS = "A labels list of the form <key>:<value>,<key>:<value>. " \
+         "Any comma and colon in <value> must be escaped with `\\`."
 
-LABELS_FILTER_RULES = "A list of labels' filter rules separated with an " \
-                      "`and`. Labels' filter rules must be one of: " \
-                      "<key>=<value>, <key>!=<value>, <key> is null, " \
-                      "<key> is not null. <value> can be a single string or " \
-                      "a list of strings of the form " \
-                      "[<value1>,<value2>,...]. E.g. \"a=b and c!=[d,e] and " \
-                      "f is not null\". The labels' filter rules will be " \
-                      "saved in lower case."
+LABELS_FILTER_RULES = "A labels' filter rule. Labels' filter rules must be " \
+                      "one of: <key>=<value>, <key>!=<value>, <key> is null," \
+                      " <key> is not null. <value> can be a single string " \
+                      "or a list of strings of the form " \
+                      "[<value1>,<value2>,...]. Any comma in <value> must " \
+                      "be escaped with `\\`. The labels' filter rules " \
+                      "will be saved in lower case."
 
-ATTRS_FILTER_RULES = "A list of attributes' filter rules separated with an " \
-                     "`and`. Attributes' filter rules must be one of:  " \
-                     "<key>=<value>, <key>!=<value>, <key> contains " \
-                     "<value>, <key> does-not-contain <value>, " \
+ATTRS_FILTER_RULES = "An attributes' filter rule. Attributes' filter rules " \
+                     "must be one of:  <key>=<value>, <key>!=<value>, " \
+                     "<key> contains <value>, " \
+                     "<key> does-not-contain <value>, " \
                      "<key> starts-with <value>, <key> ends-with <value>. " \
                      "<key> is not empty. <value> can be a single string or " \
                      "a list of strings of the form [<value1>,<value2>,...]." \
@@ -521,11 +521,12 @@ ATTRS_FILTER_RULES = "A list of attributes' filter rules separated with an " \
 
 DEPLOYMENTS_ATTRS_FILTER_RULES = ATTRS_FILTER_RULES + \
                                  '[blueprint_id, created_by, site_name, ' \
-                                 'schedules]. E.g. \"blueprint_id contains ' \
-                                 'app and created_by starts-with john\".'
+                                 'schedules]. This argument can be used ' \
+                                 'multiple times'
 
-BLUEPRINTS_ATTRS_FILTER_RULES = ATTRS_FILTER_RULES + '[created_by]. E.g. ' \
-                                                     '\"created_by=admin\"'
+BLUEPRINTS_ATTRS_FILTER_RULES = ATTRS_FILTER_RULES + \
+                                '[created_by]. This argument can be ' \
+                                'used multiple times'
 
 FILTER_ID = 'Filter results according to the specified filter'
 

--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -241,7 +241,8 @@ def delete(blueprint_id, force, logger, client, tenant_name):
 
 
 @cfy.command(name='list', short_help='List blueprints')
-@cfy.options.blueprint_filter_methods
+@cfy.options.filter_id
+@cfy.options.blueprint_filter_rules
 @cfy.options.sort_by()
 @cfy.options.descending
 @cfy.options.common_options
@@ -254,7 +255,8 @@ def delete(blueprint_id, force, logger, client, tenant_name):
 @cfy.assert_manager_active()
 @cfy.pass_client()
 @cfy.pass_logger
-def manager_list(resource_filter_methods,
+def manager_list(filter_id,
+                 filter_rules,
                  sort_by,
                  descending,
                  tenant_name,
@@ -277,8 +279,6 @@ def manager_list(resource_filter_methods,
 
     utils.explicit_tenant_name_message(tenant_name, logger)
     logger.info('Listing all blueprints...')
-    filter_id = resource_filter_methods['filter_id']
-    filter_rules = resource_filter_methods['filter_rules']
 
     blueprints_list = client.blueprints.list(
         sort=sort_by,
@@ -585,7 +585,8 @@ def add_blueprint_labels(labels_list,
                          logger,
                          client,
                          tenant_name):
-    """LABELS_LIST: <key>:<value>,<key>:<value>"""
+    """LABELS_LIST: <key>:<value>,<key>:<value>.
+    Any comma and colon in <value> must be escaped with '\\'."""
     add_labels(blueprint_id, 'blueprint', client.blueprints, labels_list,
                logger, tenant_name)
 
@@ -606,7 +607,7 @@ def delete_blueprint_labels(label,
                             tenant_name):
     """
     LABEL: Can be either <key>:<value> or <key>. If <key> is provided,
-    all labels associated with this key will be deleted from the blueprint.
+    all labels associated with this key will be deleted from the deployment.
     """
     delete_labels(blueprint_id, 'blueprint', client.blueprints, label,
                   logger, tenant_name)

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -197,7 +197,8 @@ def _print_single_update(deployment_update_dict,
 @cfy.command(name='list', short_help='List deployments [manager only]')
 @cfy.options.blueprint_id()
 @click.option('--group-id', '-g')
-@cfy.options.deployment_filter_methods
+@cfy.options.filter_id
+@cfy.options.deployment_filter_rules
 @cfy.options.sort_by()
 @cfy.options.descending
 @cfy.options.tenant_name_for_list(
@@ -212,7 +213,8 @@ def _print_single_update(deployment_update_dict,
 @cfy.pass_logger
 def manager_list(blueprint_id,
                  group_id,
-                 resource_filter_methods,
+                 filter_id,
+                 filter_rules,
                  sort_by,
                  descending,
                  all_tenants,
@@ -233,9 +235,6 @@ def manager_list(blueprint_id,
             blueprint_id))
     else:
         logger.info('Listing all deployments...')
-
-    filter_id = resource_filter_methods['filter_id']
-    filter_rules = resource_filter_methods['filter_rules']
 
     deployments = client.deployments.list(sort=sort_by,
                                           is_descending=descending,
@@ -894,7 +893,10 @@ def add_deployment_labels(labels_list,
                           logger,
                           client,
                           tenant_name):
-    """LABELS_LIST: <key>:<value>,<key>:<value>"""
+    """
+    LABELS_LIST: <key>:<value>,<key>:<value>.
+    Any comma and colon in <value> must be escaped with '\\'.
+    """
     add_labels(deployment_id, 'deployment', client.deployments, labels_list,
                logger, tenant_name)
 

--- a/cloudify_cli/exceptions.py
+++ b/cloudify_cli/exceptions.py
@@ -47,3 +47,11 @@ class EventProcessingTimeoutError(RuntimeError):
     def __init__(self, execution_id, message):
         self.execution_id = execution_id
         self.message = message
+
+
+class LabelsValidationError(CloudifyValidationError):
+    def __init__(self, err_label, err_reason):
+        super(LabelsValidationError, self).__init__(
+            'ERROR: The label `{0}` is invalid. '
+            '{1}'.format(err_label, err_reason)
+        )

--- a/cloudify_cli/filters_utils.py
+++ b/cloudify_cli/filters_utils.py
@@ -118,7 +118,7 @@ class LabelsFilterRule(FilterRule):
     def __str__(self):
         cli_operator = REVERSED_OPERATOR_MAPPING[self['operator']]
         if self['operator'] in ('is_null', 'is_not_null'):
-            return '{0} {1}'.format(self['key'], cli_operator)
+            return '"{0} {1}"'.format(self['key'], cli_operator)
         self['values'] = [val.replace(',', '\\,').replace(':', '\\:')
                           .replace('$', '\\$') for val in self['values']]
         return super(LabelsFilterRule, self).__str__(cli_operator)
@@ -155,8 +155,8 @@ class AttrsFilterRule(FilterRule):
         filter_rule_operator = self['operator']
         cli_operator = REVERSED_OPERATOR_MAPPING[filter_rule_operator]
         if filter_rule_operator == 'is_not_empty':
-            return '{key} {operator}'.format(key=self['key'],
-                                             operator=cli_operator)
+            return '"{key} {operator}"'.format(key=self['key'],
+                                               operator=cli_operator)
         if filter_rule_operator in ('starts_with', 'ends_with', 'contains',
                                     'not_contains'):
             cli_operator = ' {0} '.format(cli_operator)

--- a/cloudify_cli/filters_utils.py
+++ b/cloudify_cli/filters_utils.py
@@ -36,7 +36,10 @@ class InvalidLabelsFilterRuleFormat(CloudifyCliError):
             'The labels filter rule `{0}` is not in the right format. It must '
             'be one of: <key>=<value>, <key>!=<value>, <key> is null, '
             '<key> is not null. <value> can be a single string or a list of '
-            'strings of the form [<value1>,<value2>,...]'.format(
+            'strings of the form [<value1>,<value2>,...]. '
+            '<value> cannot contain `"`, `\\n` and `\\t`, plus, any comma in '
+            '<value> must be escaped with `\\`. <key> can contain only '
+            'letters, digits and the characters `-`, `.` and `_`'.format(
                 labels_filter_value)
         )
 
@@ -49,14 +52,13 @@ class InvalidAttributesFilterRuleFormat(CloudifyCliError):
             '<key> contains <value>, <key> does-not-contain <value>, '
             '<key> starts-with <value>, <key> ends-with <value>, '
             '<key> is not empty. <value> can be a single string or a list of '
-            'strings of the form [<value1>,<value2>,...]'.format(
-                labels_filter_value)
+            'strings of the form [<value1>,<value2>,...]. <key> and <value> '
+            'can contain only letters, digits and the characters `-`, `.` '
+            'and `_`'.format(labels_filter_value)
         )
 
 
 class FilterRule(dict):
-    format_exception = None
-
     def __init__(self, key, values, operator, filter_rule_type):
         super(FilterRule, self).__init__()
         self['key'] = key
@@ -64,113 +66,90 @@ class FilterRule(dict):
         self['operator'] = operator
         self['type'] = filter_rule_type
 
-    @classmethod
-    def _parse_filter_rule(cls, str_filter_rule, operator):
-        """Parse a filter rule
-
-        :param str_filter_rule: One of:
-               <key>=<value>,<key>=[<value1>,<value2>,...],
-               <key>!=<value>, <key>!=[<value1>,<value2>,...],
-               <key> contains <value>, <key> contains [<value1>,<value2>,..],
-               <key> does-not-contain  <value>,
-               <key> does-not-contain [<value1>,<value2>,..],
-               <key> starts-with <value>, <key> starts-with [<value1>,
-               <value2>,..],
-               <key> ends-with <value>, <key> ends-with [<value1>,<value2>,..],
-        :param operator: Either '=' / '!=' / 'contains' / 'not-contains' /
-               'starts-with' / 'ends-with'
-        :return: The filter_rule's key and value(s) stripped of whitespaces
-        """
-        try:
-            raw_rule_key, raw_rule_value = str_filter_rule.split(operator)
-        except ValueError:  # e.g. a=b=c
-            raise cls.format_exception(str_filter_rule)
-
-        rule_key = raw_rule_key.strip()
-        rule_values = cls._get_rule_values(raw_rule_value.strip())
-
-        return rule_key, rule_values
-
     @staticmethod
     def _get_rule_values(raw_rule_value):
+        raw_rule_value = raw_rule_value.replace('\\,', '\x00')
         if raw_rule_value.startswith('[') and raw_rule_value.endswith(']'):
-            return raw_rule_value.strip('[]').split(',')
+            raw_values_list = raw_rule_value.strip('[]').split(',')
+        else:
+            raw_values_list = [raw_rule_value]
 
-        return [raw_rule_value]
+        return [value.replace('\x00', ',') for value in raw_values_list]
 
     def __str__(self, cli_operator):
-        if len(self['values']) == 1:
-            return '{key}{operator}{values}'.format(key=self['key'],
-                                                    operator=cli_operator,
-                                                    values=self['values'][0])
+        values = (self['values'][0] if len(self['values']) == 1 else
+                  '[{0}]'.format(','.join(self['values'])))
 
-        return '{key}{operator}[{values}]'.format(
-            key=self['key'], operator=cli_operator,
-            values=','.join(self['values']))
+        return '"{key}{operator}{values}"'.format(key=self['key'],
+                                                  operator=cli_operator,
+                                                  values=values)
 
 
 class LabelsFilterRule(FilterRule):
-    format_exception = InvalidLabelsFilterRuleFormat
-
     def __init__(self, key, values, operator):
         super(LabelsFilterRule, self).__init__(key, values, operator, 'label')
 
     @classmethod
     def from_string(cls, str_filter_rule):
-        if '!=' in str_filter_rule:
-            key, values = cls._parse_filter_rule(str_filter_rule, '!=')
-            return cls(key, values, OPERATOR_MAPPING['!='])
+        match_equal = re.match(r'^([\w\-\.]+)(=)([^\n\t\"]+)$',
+                               str_filter_rule)
+        match_not_equal = re.match(r'^([\w\-\.]+)(!=)([^\n\t\"]+)$',
+                                   str_filter_rule)
+        equal_matching = match_equal or match_not_equal
+        if equal_matching:
+            key = equal_matching.group(1).lower()
+            operator = equal_matching.group(2)
+            values = cls._get_rule_values(equal_matching.group(3))
+            return cls(key, values, OPERATOR_MAPPING[operator])
 
-        elif '=' in str_filter_rule:
-            key, values = cls._parse_filter_rule(str_filter_rule, '=')
-            return cls(key, values, OPERATOR_MAPPING['='])
+        match_null = re.match(r'^([\w\-\.]+) (is null)$', str_filter_rule)
+        match_not_null = re.match(r'^([\w\-\.]+) (is not null)$',
+                                  str_filter_rule)
+        null_matching = match_null or match_not_null
 
-        elif 'null' in str_filter_rule:
-            match_null = re.match(r'(\S+) is null', str_filter_rule)
-            match_not_null = re.match(r'(\S+) is not null', str_filter_rule)
-            if match_null:
-                key = match_null.group(1).lower()
-                return cls(key, [], OPERATOR_MAPPING['is null'])
-            elif match_not_null:
-                key = match_not_null.group(1).lower()
-                return cls(key, [], OPERATOR_MAPPING['is not null'])
-            else:
-                raise cls.format_exception(str_filter_rule)
+        if null_matching:
+            key = null_matching.group(1).lower()
+            operator = null_matching.group(2)
+            return cls(key, [], OPERATOR_MAPPING[operator])
 
-        else:
-            raise cls.format_exception(str_filter_rule)
+        # If we got here, the labels filter is not in the right format
+        raise InvalidLabelsFilterRuleFormat(str_filter_rule)
 
     def __str__(self):
         cli_operator = REVERSED_OPERATOR_MAPPING[self['operator']]
         if self['operator'] in ('is_null', 'is_not_null'):
             return '{0} {1}'.format(self['key'], cli_operator)
-
+        self['values'] = [val.replace(',', '\\,').replace('$', '\\$')
+                          for val in self['values']]
         return super(LabelsFilterRule, self).__str__(cli_operator)
 
 
 class AttrsFilterRule(FilterRule):
-    format_exception = InvalidAttributesFilterRuleFormat
-
     def __init__(self, key, values, operator):
         super(AttrsFilterRule, self).__init__(key, values, operator,
                                               'attribute')
 
     @classmethod
     def from_string(cls, str_filter_rule):
-        for operator in ['!=', '=', 'contains', 'does-not-contain',
-                         'starts-with', 'ends-with']:
-            if operator in str_filter_rule:
-                key, values = cls._parse_filter_rule(str_filter_rule, operator)
-                return cls(key, values, OPERATOR_MAPPING[operator])
+        for operator in ['!=', '=', ' contains ', ' does-not-contain ',
+                         ' starts-with ', ' ends-with ']:
+            matching = re.match(
+                r'^([\w\-\.]+)({0})([\w\-\.]+|\[[\w\-\.\,]+\])$'.format(
+                    operator), str_filter_rule)
+            if matching:
+                key = matching.group(1).lower()
+                operator = matching.group(2)
+                values = cls._get_rule_values(matching.group(3))
+                return cls(key, values, OPERATOR_MAPPING[operator.strip()])
 
-        # None of the operators in the list is in str_filter_rule
-        match_not_empty = re.match(r'(\S+) is not empty', str_filter_rule)
+        # The str_filter_rule didn't match the pattern with any operator
+        match_not_empty = re.match(r'^([\w\-\.]+) is not empty$',
+                                   str_filter_rule)
         if match_not_empty:
             key = match_not_empty.group(1).lower()
             return cls(key, [], OPERATOR_MAPPING['is not empty'])
 
-        else:
-            raise cls.format_exception(str_filter_rule)
+        raise InvalidAttributesFilterRuleFormat(str_filter_rule)
 
     def __str__(self):
         filter_rule_operator = self['operator']
@@ -283,30 +262,28 @@ def _modify_filter_details(filter_details):
         filter_details['labels_filter_rules'])
 
 
-def create_labels_filter_rules_list(labels_filter_rules_string):
+def create_labels_filter_rules_list(raw_labels_filter_rules_list):
     """Validate and parse a string of labels filter rules
 
-    :param labels_filter_rules_string: A string of filter rules of type `label`
-           separated with an `and`.
+    :param raw_labels_filter_rules_list: A list of filter rules of type
+           `label`, formatted as strings.
     :return The list of filter rules that matches the provided string.
     """
-    raw_labels_filter_rules = labels_filter_rules_string.split(' and ')
     labels_filter_rules = [LabelsFilterRule.from_string(raw_filter_rule) for
-                           raw_filter_rule in raw_labels_filter_rules]
+                           raw_filter_rule in raw_labels_filter_rules_list]
 
     return labels_filter_rules
 
 
-def create_attributes_filter_rules_list(attributes_filter_rules_string):
+def create_attributes_filter_rules_list(raw_attributes_filter_rules_list):
     """Validate and parse a list of attributes filter rules
 
-    :param attributes_filter_rules_string: A string of filter rules of type
-           `attribute` separated with an `and`.
+    :param raw_attributes_filter_rules_list: A list of filter rules of type
+           `attribute`, formatted as strings.
     :return The list of filter rules that matches the provided string.
     """
-    raw_attrs_filter_rules = attributes_filter_rules_string.split(' and ')
     attrs_filter_rules = [AttrsFilterRule.from_string(raw_filter_rule) for
-                          raw_filter_rule in raw_attrs_filter_rules]
+                          raw_filter_rule in raw_attributes_filter_rules_list]
 
     return attrs_filter_rules
 
@@ -339,10 +316,11 @@ def _filter_rules_to_string(filter_rules):
 
         str_filter_rules_list.append(str(filter_rule))
 
-    return '"{0}"'.format(' and '.join(str_filter_rules_list))
+    return (str_filter_rules_list[0] if len(str_filter_rules_list) == 1
+            else str_filter_rules_list)
 
 
 def _modify_err_msg(err_filter_rule, err_reason):
     str_filter_rule = _filter_rules_to_string([err_filter_rule])
-    return 'The filter rule {0} is invalid. {1}'.format(str_filter_rule,
-                                                        err_reason)
+    return 'The filter rule `{0}` is invalid. {1}'.format(str_filter_rule,
+                                                          err_reason)

--- a/cloudify_cli/filters_utils.py
+++ b/cloudify_cli/filters_utils.py
@@ -5,6 +5,7 @@ from .exceptions import CloudifyCliError
 from .table import print_data, print_details
 from .utils import validate_visibility, handle_client_error
 
+from cloudify._compat import PY2
 from cloudify_rest_client.exceptions import InvalidFilterRule
 
 FILTERS_COLUMNS = ['id', 'labels_filter_rules', 'attrs_filter_rules',
@@ -78,7 +79,9 @@ class FilterRule(dict):
 
     def __str__(self, cli_operator):
         values = (self['values'][0] if len(self['values']) == 1 else
-                  '[{0}]'.format(','.join(self['values'])))
+                  u'[{0}]'.format(','.join(self['values'])))
+        if PY2:
+            values = values.encode('utf-8')
 
         return '"{key}{operator}{values}"'.format(key=self['key'],
                                                   operator=cli_operator,

--- a/cloudify_cli/filters_utils.py
+++ b/cloudify_cli/filters_utils.py
@@ -195,6 +195,14 @@ def get_filter(resource_name, filter_id, tenant_name, logger, client):
                     filter_id)
         filter_details = client.get(filter_id)
         _modify_filter_details(filter_details)
+        labels_filter_rules = filter_details['labels_filter_rules']
+        attrs_filter_rules = filter_details['attrs_filter_rules']
+        if labels_filter_rules and isinstance(labels_filter_rules, list):
+            filter_details['labels_filter_rules'] = ', '.join(
+                labels_filter_rules)
+        if attrs_filter_rules and isinstance(attrs_filter_rules, list):
+            filter_details['attrs_filter_rules'] = ', '.join(
+                attrs_filter_rules)
         print_details(filter_details,
                       "Requested {0}' filter info:".format(resource_name))
 

--- a/cloudify_cli/labels_utils.py
+++ b/cloudify_cli/labels_utils.py
@@ -1,4 +1,5 @@
 import json
+from string import ascii_letters
 
 from .table import print_data
 from .utils import explicit_tenant_name_message
@@ -11,9 +12,10 @@ def modify_resource_labels(resource_list):
         raw_labels_list = element.get('labels')
         if raw_labels_list:
             for raw_label in raw_labels_list:
-                resource_labels_list.append(
-                    raw_label.key + ':' + raw_label.value)
-            element['labels'] = ','.join(resource_labels_list)
+                label_value = _format_label_value(raw_label.value)
+                resource_labels_list.append(raw_label.key + ':' +
+                                            label_value.strip('""'))
+            element['labels'] = '"{0}"'.format(','.join(resource_labels_list))
 
 
 def list_labels(resource_id,
@@ -46,10 +48,26 @@ def get_output_resource_labels(raw_resource_labels):
 
 
 def get_printable_resource_labels(resource_labels):
-    return [
-        {'key': resource_label_key, 'values': resource_label_values} for
-        resource_label_key, resource_label_values in resource_labels.items()
-    ]
+    printable_labels = []
+    for resource_label_key, resource_label_values in resource_labels.items():
+        formatted_label_values = [_format_label_value(label_value) for
+                                  label_value in resource_label_values]
+        printable_labels.append({'key': resource_label_key,
+                                 'values': formatted_label_values})
+    return printable_labels
+
+
+def _format_label_value(label_value):
+    label_value = label_value.replace(',', '\\,').replace(':', '\\:').\
+        replace('$', '\\$')
+    if label_value_needs_quotes(label_value):
+        label_value = '"{0}"'.format(label_value)
+    return label_value
+
+
+def label_value_needs_quotes(label_value):
+    allowed_chars = ascii_letters + '-_.0123456789'
+    return any(char not in allowed_chars for char in label_value)
 
 
 def add_labels(resource_id,

--- a/cloudify_cli/labels_utils.py
+++ b/cloudify_cli/labels_utils.py
@@ -1,5 +1,4 @@
 import json
-from string import ascii_letters
 
 from .table import print_data
 from .utils import explicit_tenant_name_message
@@ -60,14 +59,7 @@ def get_printable_resource_labels(resource_labels):
 def _format_label_value(label_value):
     label_value = label_value.replace(',', '\\,').replace(':', '\\:').\
         replace('$', '\\$')
-    if label_value_needs_quotes(label_value):
-        label_value = '"{0}"'.format(label_value)
-    return label_value
-
-
-def label_value_needs_quotes(label_value):
-    allowed_chars = ascii_letters + '-_.0123456789'
-    return any(char not in allowed_chars for char in label_value)
+    return '"{0}"'.format(label_value)
 
 
 def add_labels(resource_id,

--- a/cloudify_cli/tests/cfy.py
+++ b/cloudify_cli/tests/cfy.py
@@ -24,6 +24,7 @@ import click.testing as clicktest
 from testfixtures import log_capture
 
 from cloudify.utils import setup_logger
+from cloudify._compat import PY2, text_type
 
 from .. import main  # NOQA
 from .. import env
@@ -61,7 +62,17 @@ def invoke(command, capture, context=None):
 
     cfy = clicktest.CliRunner()
 
-    lexed_command = shlex.split(command)
+    if PY2:
+        if isinstance(command, text_type):
+            command = command.encode('utf-8')
+            parts = shlex.split(command)
+            lexed_command = [p.decode('utf-8') for p in parts]
+        else:
+            lexed_command = shlex.split(command)
+
+    else:
+        lexed_command = shlex.split(command)
+
     # Safety measure in case someone wrote `cfy` at the beginning
     # of the command
     if lexed_command[0] == 'cfy':

--- a/cloudify_cli/tests/commands/test_base.py
+++ b/cloudify_cli/tests/commands/test_base.py
@@ -16,7 +16,7 @@ import os
 import os as utils_os
 
 import testtools
-from mock import patch
+from mock import patch, Mock, PropertyMock
 
 from cloudify.utils import setup_logger
 from cloudify_rest_client import CloudifyClient
@@ -142,3 +142,11 @@ class CliCommandTest(testtools.TestCase):
 
     def _read_context(self):
         return env.get_profile_context()
+
+    def mock_wait_for_blueprint_upload(self, value):
+        patcher = patch(
+            'cloudify_cli.utils.wait_for_blueprint_upload',
+            Mock(return_value=PropertyMock(error=value))
+        )
+        self.addCleanup(patcher.stop)
+        patcher.start()

--- a/cloudify_cli/tests/commands/test_blueprints.py
+++ b/cloudify_cli/tests/commands/test_blueprints.py
@@ -18,13 +18,11 @@ import os
 import json
 import yaml
 import tempfile
-from mock import Mock, MagicMock, PropertyMock, patch
+from mock import Mock, MagicMock, patch
 
 from cloudify.exceptions import CommandExecutionException
-from cloudify_rest_client import blueprints
 
-from cloudify_cli.labels_utils import labels_list_to_set
-from cloudify_cli.exceptions import CloudifyCliError, CloudifyValidationError
+from cloudify_cli.exceptions import CloudifyCliError
 
 from ... import env
 from ...config import config
@@ -37,31 +35,11 @@ from .constants import (BLUEPRINTS_DIR,
 
 
 class BlueprintsTest(CliCommandTest):
-    LABELED_BLUEPRINT = blueprints.Blueprint({
-            'blueprint_id': 'bp1',
-            'labels': [
-                {'key': 'key1', 'value': 'val1',
-                 'created_at': '1', 'creator_id': 0},
-                {'key': 'key2', 'value': 'val2',
-                 'created_at': '2', 'creator_id': 0},
-                {'key': 'key2', 'value': 'val3',
-                 'created_at': '2', 'creator_id': 0},
-            ]
-        })
-
-    def _mock_wait_for_blueprint_upload(self, value):
-        patcher = patch(
-            'cloudify_cli.utils.wait_for_blueprint_upload',
-            MagicMock(return_value=PropertyMock(error=value))
-        )
-        self.addCleanup(patcher.stop)
-        patcher.start()
-
     def setUp(self):
         super(BlueprintsTest, self).setUp()
         self.client.license.check = Mock()
         self.use_manager()
-        self._mock_wait_for_blueprint_upload(False)
+        self.mock_wait_for_blueprint_upload(False)
 
     def test_blueprints_list(self):
         self.client.blueprints.list = MagicMock(
@@ -455,77 +433,3 @@ class BlueprintsTest(CliCommandTest):
         self.invoke('cfy blueprints upload {0} -b my_blueprint_id '
                     '--blueprint-filename blueprint.yaml -l private'
                     .format(SAMPLE_ARCHIVE_PATH))
-
-    def test_blueprint_upload_failure_with_invalid_labels(self):
-        cmd = 'cfy blueprints upload {0} -b bp1 '.format(SAMPLE_ARCHIVE_PATH)
-        self.invoke(cmd + '--labels env:',
-                    err_str_segment='The value of one or more labels is empty',
-                    exception=CloudifyValidationError)
-
-        self.invoke(cmd + '--labels :aws',
-                    err_str_segment='The key of one or more labels is empty',
-                    exception=CloudifyValidationError)
-
-        self.invoke(cmd + '--labels aws',
-                    err_str_segment='form <key>:<value>,<key>:<value>',
-                    exception=CloudifyValidationError)
-
-    def test_blueprint_upload_with_labels(self):
-        cmd = 'cfy blueprints upload {0} -b bp1 '.format(SAMPLE_ARCHIVE_PATH)
-        self.client.blueprints.upload = Mock()
-        self.invoke(cmd + '--labels key1:val1,key2:val2')
-        call_args = list(self.client.blueprints.upload.call_args)
-        self.assertEqual(call_args[1]['labels'],
-                         [{'key1': 'val1'}, {'key2': 'val2'}])
-
-    def test_blueprint_labels_list(self):
-        self.client.blueprints.get = Mock(return_value=self.LABELED_BLUEPRINT)
-        raw_outcome = self.invoke('cfy blueprints labels list bp1 --json')
-        labels = json.loads(raw_outcome.output)
-        self.assertEqual(labels, {'key1': ['val1'], 'key2': ['val2', 'val3']})
-
-    def test_blueprint_labels_add(self):
-        self.client.blueprints.get = Mock(return_value=self.LABELED_BLUEPRINT)
-        self.client.blueprints.update = Mock()
-        self.invoke(
-            'cfy blueprints labels add key1:val1,key2:val1,key3:val1 bp1')
-        call_args = list(self.client.blueprints.update.call_args)
-        self.assertEqual(labels_list_to_set(call_args[0][1]['labels']),
-                         labels_list_to_set([{'key1': 'val1'},
-                                             {'key2': 'val1'},
-                                             {'key2': 'val2'},
-                                             {'key2': 'val3'},
-                                             {'key3': 'val1'}]))
-
-    def test_blueprint_labels_delete_failure_with_invalid_label(self):
-        self.invoke('cfy blueprints labels delete key1:val1,key2:val2 bp1',
-                    err_str_segment='either <key>:<value> or <key>',
-                    exception=CloudifyValidationError)
-
-        self.invoke('cfy blueprints labels delete a@ bp1',
-                    err_str_segment='provided key contains illegal characters',
-                    exception=CloudifyValidationError)
-
-        self.invoke('cfy blueprints labels delete key1: bp1',
-                    err_str_segment='value of the provided label is empty',
-                    exception=CloudifyValidationError)
-
-        self.invoke('cfy blueprints labels delete :val1 bp1',
-                    err_str_segment='key of the provided label is empty',
-                    exception=CloudifyValidationError)
-
-    def test_blueprint_labels_delete_label(self):
-        self.client.blueprints.get = Mock(return_value=self.LABELED_BLUEPRINT)
-        self.client.blueprints.update = Mock()
-        self.invoke('cfy blueprints labels delete key2:val2 bp1')
-        call_args = list(self.client.blueprints.update.call_args)
-        self.assertEqual(labels_list_to_set(call_args[0][1]['labels']),
-                         labels_list_to_set([{'key1': 'val1'},
-                                             {'key2': 'val3'}]))
-
-    def test_blueprint_labels_delete_key(self):
-        self.client.blueprints.get = Mock(return_value=self.LABELED_BLUEPRINT)
-        self.client.blueprints.update = Mock()
-        self.invoke('cfy blueprints labels delete key2 bp1')
-        call_args = list(self.client.blueprints.update.call_args)
-        self.assertEqual(call_args[0][1]['labels'], [{'key1': 'val1'}])

--- a/cloudify_cli/tests/commands/test_deployments.py
+++ b/cloudify_cli/tests/commands/test_deployments.py
@@ -41,7 +41,6 @@ from cloudify_rest_client.deployment_modifications import (
 from cloudify_rest_client.responses import ListResponse, Metadata
 
 from cloudify_cli.constants import DEFAULT_TENANT_NAME
-from cloudify_cli.labels_utils import labels_list_to_set
 from cloudify_cli.exceptions import CloudifyCliError, CloudifyValidationError
 
 from ... import exceptions
@@ -323,19 +322,6 @@ class DeploymentUpdatesTest(CliCommandTest):
 
 
 class DeploymentsTest(CliCommandTest):
-
-    LABELED_DEPLOYMENT = deployments.Deployment({
-            'deployment_id': 'dep1',
-            'labels': [
-                {'key': 'key1', 'value': 'val1',
-                 'created_at': '1', 'creator_id': 0},
-                {'key': 'key2', 'value': 'val2',
-                 'created_at': '2', 'creator_id': 0},
-                {'key': 'key2', 'value': 'val3',
-                 'created_at': '2', 'creator_id': 0},
-            ]
-        })
-
     def setUp(self):
         super(DeploymentsTest, self).setUp()
         self.use_manager()
@@ -696,85 +682,6 @@ class DeploymentsTest(CliCommandTest):
         self.invoke('cfy deployments set-site deployment_1 --site-name :site',
                     err_str_segment=error_msg,
                     exception=CloudifyValidationError)
-
-    def test_deployment_create_failure_with_invalid_labels(self):
-        self.invoke('cfy deployments create dep1 --labels env:',
-                    err_str_segment='The value of one or more labels is empty',
-                    exception=CloudifyValidationError)
-
-        self.invoke('cfy deployments create dep1 --labels :aws',
-                    err_str_segment='The key of one or more labels is empty',
-                    exception=CloudifyValidationError)
-
-        self.invoke('cfy deployments create dep1 --labels aws',
-                    err_str_segment='form <key>:<value>,<key>:<value>',
-                    exception=CloudifyValidationError)
-
-    def test_deployment_create_with_labels(self):
-        self.client.deployments.create = Mock()
-        self.invoke('cfy deployments create -b bp1 dep1 '
-                    '--labels key1:val1,key2:val2')
-        call_args = list(self.client.deployments.create.call_args)
-        self.assertEqual(call_args[1]['labels'],
-                         [{'key1': 'val1'}, {'key2': 'val2'}])
-
-    def test_deployment_labels_list(self):
-        self.client.deployments.get = Mock(
-            return_value=self.LABELED_DEPLOYMENT)
-        raw_outcome = self.invoke('cfy deployments labels list dep1 --json')
-        labels = json.loads(raw_outcome.output)
-        self.assertEqual(labels, {'key1': ['val1'], 'key2': ['val2', 'val3']})
-
-    def test_deployment_labels_add(self):
-        self.client.deployments.get = Mock(
-            return_value=self.LABELED_DEPLOYMENT)
-        self.client.deployments.update_labels = Mock()
-        self.invoke(
-            'cfy deployments labels add key1:val1,key2:val1,key3:val1 dep1')
-        call_args = list(self.client.deployments.update_labels.call_args)
-        self.assertEqual(labels_list_to_set(call_args[0][1]),
-                         labels_list_to_set([{'key1': 'val1'},
-                                             {'key2': 'val1'},
-                                             {'key2': 'val2'},
-                                             {'key2': 'val3'},
-                                             {'key3': 'val1'}]))
-
-    def test_deployment_labels_delete_failure_with_invalid_label(self):
-        self.invoke('cfy deployments labels delete key1:val1,key2:val2 dep1',
-                    err_str_segment='either <key>:<value> or <key>',
-                    exception=CloudifyValidationError)
-
-        self.invoke('cfy deployments labels delete a@ dep1',
-                    err_str_segment='provided key contains illegal characters',
-                    exception=CloudifyValidationError)
-
-        self.invoke('cfy deployments labels delete key1: dep1',
-                    err_str_segment='value of the provided label is empty',
-                    exception=CloudifyValidationError)
-
-        self.invoke('cfy deployments labels delete :val1 dep1',
-                    err_str_segment='key of the provided label is empty',
-                    exception=CloudifyValidationError)
-
-    def test_deployment_labels_delete_label(self):
-        self.client.deployments.get = Mock(
-            return_value=self.LABELED_DEPLOYMENT)
-        self.client.deployments.update_labels = Mock()
-        self.invoke(
-            'cfy deployments labels delete key2:val2 dep1')
-        call_args = list(self.client.deployments.update_labels.call_args)
-        self.assertEqual(labels_list_to_set(call_args[0][1]),
-                         labels_list_to_set([{'key1': 'val1'},
-                                             {'key2': 'val3'}]))
-
-    def test_deployment_labels_delete_key(self):
-        self.client.deployments.get = Mock(
-            return_value=self.LABELED_DEPLOYMENT)
-        self.client.deployments.update_labels = Mock()
-        self.invoke(
-            'cfy deployments labels delete key2 dep1')
-        call_args = list(self.client.deployments.update_labels.call_args)
-        self.assertEqual(call_args[0][1], [{'key1': 'val1'}])
 
     def _test_deployment_inputs(self, exception_type,
                                 inputs, expected_outputs=None):

--- a/cloudify_cli/tests/commands/test_filters.py
+++ b/cloudify_cli/tests/commands/test_filters.py
@@ -126,10 +126,13 @@ class FiltersTest(CliCommandTest):
 
     def test_get_filters(self):
         cmd = '{0} get {1}'.format(self.prefix, FILTER_ID)
-        self.filters_client.get = Mock()
-        self.invoke(cmd)
+        self.filters_client.get = Mock(return_value=self.example_filter)
+        raw_output = self.invoke(cmd).output
         call_args = list(self.filters_client.get.call_args)
         self.assertEqual(call_args[0][0], FILTER_ID)
+        self.assertIn('"key=va\\, l\xf3e", "ke.y=[val\\:\\$,va\xf3lue]"',
+                      raw_output)
+        self.assertIn('"created_by=val-u.e"', raw_output)
 
     def test_get_filters_missing_filter_id(self):
         self._test_missing_argument('{} get'.format(self.prefix), 'FILTER_ID')
@@ -203,9 +206,7 @@ class FiltersTest(CliCommandTest):
                                     'FILTER_ID')
 
     def test_list_with_filters(self):
-        self.resource_client.list = Mock(
-            return_value=MockListResponse()
-        )
+        self.resource_client.list = Mock(return_value=MockListResponse())
         self.invoke('cfy {resource} list --filter-id {filter_id} '
                     '-ar {attrs_rules} -lr {labels_rules}'.format(
                      resource=self.resource, filter_id=FILTER_ID,

--- a/cloudify_cli/tests/commands/test_filters.py
+++ b/cloudify_cli/tests/commands/test_filters.py
@@ -1,4 +1,5 @@
 from mock import MagicMock
+from collections import OrderedDict
 
 from cloudify_cli.exceptions import CloudifyCliError
 from cloudify_cli.filters_utils import (InvalidLabelsFilterRuleFormat,
@@ -7,55 +8,53 @@ from cloudify_cli.filters_utils import (InvalidLabelsFilterRuleFormat,
 from .mocks import MockListResponse
 from .test_base import CliCommandTest
 
-LABELS_RULES_STR = "a=b and c=[d,e] and f!=g and h!=[i,j] and k is null " \
-                   "and l is not null"
-LABELS_RULES_LIST = [
-    {'key': 'a', 'values': ['b'], 'operator': 'any_of', 'type': 'label'},
-    {'key': 'c', 'values': ['d', 'e'], 'operator': 'any_of',
-     'type': 'label'},
-    {'key': 'f', 'values': ['g'], 'operator': 'not_any_of',
-     'type': 'label'},
-    {'key': 'h', 'values': ['i', 'j'], 'operator': 'not_any_of',
-     'type': 'label'},
-    {'key': 'k', 'values': [], 'operator': 'is_null', 'type': 'label'},
-    {'key': 'l', 'values': [], 'operator': 'is_not_null', 'type': 'label'},
-]
+MATCHING_LABELS_RULES = OrderedDict([
+    ('a="b and c"', {'key': 'a', 'values': ['b and c'], 'operator': 'any_of',
+                     'type': 'label'}),
+    ('c=["d,e\\,f"]', {'key': 'c', 'values': ['d', 'e,f'],
+                       'operator': 'any_of', 'type': 'label'}),
+    ('f!=g', {'key': 'f', 'values': ['g'], 'operator': 'not_any_of',
+              'type': 'label'}),
+    ('h!=["i:,j k\xf3"]', {'key': 'h', 'values': ['i:', 'j k\xf3'],
+                           'operator': 'not_any_of', 'type': 'label'}),
+    ('"k_l is null"', {'key': 'k_l', 'values': [], 'operator': 'is_null',
+                       'type': 'label'}),
+    ('"l_m-n.o is not null"', {'key': 'l_m-n.o', 'values': [],
+                               'operator': 'is_not_null', 'type': 'label'})
+])
 
-# This are not real attributes, but it doesn't matter for the CLI tests
-ATTRS_RULES_STR = "a=b and c=[d,e] and f!=g and h!=[i,j] and " \
-                  "k contains l and m contains [n,o] and " \
-                  "p does-not-contain q and r does-not-contain [s,t] " \
-                  "and u starts-with v and w starts-with [x,y] and " \
-                  "z ends-with aa and ab ends-with [ac,ad] and " \
-                  "ae is not empty"
-ATTRS_RULES_LIST = [
-    {'key': 'a', 'values': ['b'], 'operator': 'any_of',
-     'type': 'attribute'},
-    {'key': 'c', 'values': ['d', 'e'], 'operator': 'any_of',
-     'type': 'attribute'},
-    {'key': 'f', 'values': ['g'], 'operator': 'not_any_of',
-     'type': 'attribute'},
-    {'key': 'h', 'values': ['i', 'j'], 'operator': 'not_any_of',
-     'type': 'attribute'},
-    {'key': 'k', 'values': ['l'], 'operator': 'contains',
-     'type': 'attribute'},
-    {'key': 'm', 'values': ['n', 'o'], 'operator': 'contains',
-     'type': 'attribute'},
-    {'key': 'p', 'values': ['q'], 'operator': 'not_contains',
-     'type': 'attribute'},
-    {'key': 'r', 'values': ['s', 't'], 'operator': 'not_contains',
-     'type': 'attribute'},
-    {'key': 'u', 'values': ['v'], 'operator': 'starts_with',
-     'type': 'attribute'},
-    {'key': 'w', 'values': ['x', 'y'], 'operator': 'starts_with',
-     'type': 'attribute'},
-    {'key': 'z', 'values': ['aa'], 'operator': 'ends_with',
-     'type': 'attribute'},
-    {'key': 'ab', 'values': ['ac', 'ad'], 'operator': 'ends_with',
-     'type': 'attribute'},
-    {'key': 'ae', 'values': [], 'operator': 'is_not_empty',
-     'type': 'attribute'},
-]
+# These are not real attributes, but it doesn't matter for the CLI tests
+MATCHING_ATTRS_RULES = OrderedDict([
+    ('a=b', {'key': 'a', 'values': ['b'], 'operator': 'any_of',
+             'type': 'attribute'}),
+    ('c=[d,e]', {'key': 'c', 'values': ['d', 'e'], 'operator': 'any_of',
+                 'type': 'attribute'}),
+    ('f!=g', {'key': 'f', 'values': ['g'], 'operator': 'not_any_of',
+              'type': 'attribute'}),
+    ('h!=[i,j]', {'key': 'h', 'values': ['i', 'j'], 'operator': 'not_any_of',
+                  'type': 'attribute'}),
+    ('"k contains l"', {'key': 'k', 'values': ['l'], 'operator': 'contains',
+                        'type': 'attribute'}),
+    ('"m contains [n,o]"', {'key': 'm', 'values': ['n', 'o'],
+                            'operator': 'contains', 'type': 'attribute'}),
+    ('"p does-not-contain q"',
+     {'key': 'p', 'values': ['q'], 'operator': 'not_contains',
+      'type': 'attribute'}),
+    ('"r does-not-contain [s,t]"',
+     {'key': 'r', 'values': ['s', 't'], 'operator': 'not_contains',
+      'type': 'attribute'}),
+    ('"u starts-with v"', {'key': 'u', 'values': ['v'],
+                           'operator': 'starts_with', 'type': 'attribute'}),
+    ('"w starts-with [x,y]"',
+     {'key': 'w', 'values': ['x', 'y'], 'operator': 'starts_with',
+      'type': 'attribute'}),
+    ('"z ends-with aa"', {'key': 'z', 'values': ['aa'],
+                          'operator': 'ends_with', 'type': 'attribute'}),
+    ('"ab ends-with [ac,ad]"', {'key': 'ab', 'values': ['ac', 'ad'],
+                                'operator': 'ends_with', 'type': 'attribute'}),
+    ('"a-e is not empty"', {'key': 'a-e', 'values': [],
+                            'operator': 'is_not_empty', 'type': 'attribute'})
+])
 
 FILTER_ID = 'filter'
 
@@ -74,17 +73,17 @@ class FiltersTest(CliCommandTest):
 
     def test_create_filters(self):
         self.filters_client.create = MagicMock()
-        self.invoke(
-            '{cmd_prefix} create {filter_id} --labels-rules "{labels_rules}" '
-            '--attrs-rules "{attrs_rules}"'.format(
-                cmd_prefix=self.prefix,
-                filter_id=FILTER_ID,
-                labels_rules=LABELS_RULES_STR,
-                attrs_rules=ATTRS_RULES_STR))
+        cmd_prefix = self.prefix + ' create ' + FILTER_ID
+        labels_rules = ' -lr '.join(MATCHING_LABELS_RULES.keys())
+        attrs_rules = ' -ar '.join(MATCHING_ATTRS_RULES.keys())
+        self.invoke('{0} -lr {1} -ar {2}'.format(cmd_prefix, labels_rules,
+                                                 attrs_rules))
 
         call_args = list(self.filters_client.create.call_args)
         self.assertEqual(call_args[0][0], FILTER_ID)
-        self.assertEqual(call_args[0][1], LABELS_RULES_LIST + ATTRS_RULES_LIST)
+        self.assertEqual(call_args[0][1],
+                         list(MATCHING_LABELS_RULES.values()) +
+                         list(MATCHING_ATTRS_RULES.values()))
 
     def test_create_filters_missing_filter_id(self):
         cmd = '{} create'.format(self.prefix)
@@ -114,12 +113,11 @@ class FiltersTest(CliCommandTest):
 
     def test_filters_update(self):
         self.filters_client.update = MagicMock()
-        cmd_with_filter_rules = \
-            '{cmd_prefix} update {filter_id} --labels-rules "{labels_rules}"' \
-            ' --attrs-rules "{attrs_rules}"'.format(
-                cmd_prefix=self.prefix, filter_id=FILTER_ID,
-                labels_rules=LABELS_RULES_STR,
-                attrs_rules=ATTRS_RULES_STR)
+        cmd_prefix = self.prefix + ' update ' + FILTER_ID
+        labels_rules = ' -lr '.join(MATCHING_LABELS_RULES.keys())
+        attrs_rules = ' -ar '.join(MATCHING_ATTRS_RULES.keys())
+        cmd_with_filter_rules = '{0} -lr {1} -ar {2}'.format(
+            cmd_prefix, labels_rules, attrs_rules)
         cmd_with_visibility = '{cmd_prefix} update {filter_id} --visibility ' \
                               'global'.format(cmd_prefix=self.prefix,
                                               filter_id=FILTER_ID)
@@ -129,7 +127,9 @@ class FiltersTest(CliCommandTest):
         self.invoke(cmd_with_filter_rules)
         call_args = list(self.filters_client.update.call_args)
         self.assertEqual(call_args[0][0], FILTER_ID)
-        self.assertEqual(call_args[0][1], LABELS_RULES_LIST + ATTRS_RULES_LIST)
+        self.assertEqual(call_args[0][1],
+                         list(MATCHING_LABELS_RULES.values()) +
+                         list(MATCHING_ATTRS_RULES.values()))
         self.assertEqual(call_args[0][2], None)
 
         self.invoke(cmd_with_visibility)
@@ -141,7 +141,9 @@ class FiltersTest(CliCommandTest):
         self.invoke(cmd_with_filter_rules_and_visibility)
         call_args = list(self.filters_client.update.call_args)
         self.assertEqual(call_args[0][0], FILTER_ID)
-        self.assertEqual(call_args[0][1], LABELS_RULES_LIST + ATTRS_RULES_LIST)
+        self.assertEqual(call_args[0][1],
+                         list(MATCHING_LABELS_RULES.values()) +
+                         list(MATCHING_ATTRS_RULES.values()))
         self.assertEqual(call_args[0][2], 'global')
 
     def test_filters_update_invalid_filter_rules(self):
@@ -169,24 +171,19 @@ class FiltersTest(CliCommandTest):
             return_value=MockListResponse()
         )
         self.invoke('cfy {resource} list --filter-id {filter_id} '
-                    '--attrs-filter "{attrs_rules}" '
-                    '--labels-filter "{labels_rules}"'.format(
+                    '-ar {attrs_rules} -lr {labels_rules}'.format(
                      resource=self.resource, filter_id=FILTER_ID,
-                     attrs_rules=ATTRS_RULES_STR,
-                     labels_rules=LABELS_RULES_STR))
+                     attrs_rules=' -ar '.join(MATCHING_ATTRS_RULES.keys()),
+                     labels_rules=' -lr '.join(MATCHING_LABELS_RULES.keys())))
 
         call_args = list(self.resource_client.list.call_args)
-        call_args[1]['filter_rules'] = ATTRS_RULES_LIST + LABELS_RULES_LIST
+        call_args[1]['filter_rules'] = (list(MATCHING_LABELS_RULES.values()) +
+                                        list(MATCHING_ATTRS_RULES.values()))
         call_args[1]['filter_id'] = FILTER_ID
 
-    def test_deployments_list_with_invalid_filters(self):
-        self.invoke('cfy {} list --attrs-filter "e~1"'.format(self.resource),
-                    err_str_segment='The attributes filter rule `e~1`',
-                    exception=InvalidAttributesFilterRuleFormat)
-
-        self.invoke('cfy {} list --labels-filter "e is"'.format(self.resource),
-                    err_str_segment='The labels filter rule `e is`',
-                    exception=InvalidLabelsFilterRuleFormat)
+    def test_list_with_invalid_filters(self):
+        self._test_providing_invalid_filter_rules(
+            'list', 'cfy {0}'.format(self.resource))
 
     def _test_missing_argument(self, command, argument):
         outcome = self.invoke(
@@ -197,28 +194,37 @@ class FiltersTest(CliCommandTest):
         self.assertIn('missing argument', outcome.output.lower())
         self.assertIn(argument, outcome.output)
 
-    def _test_providing_invalid_filter_rules(self, command):
-        err_labels_rules = '"a=b and e is"'
-        err_attrs_rules = '"a=b and c is"'
-        err_labels_cmd = '{cmd_prefix} {command} --labels-rules ' \
-                         '{labels_rules}'.format(cmd_prefix=self.prefix,
-                                                 command=command,
-                                                 labels_rules=err_labels_rules)
-        err_attrs_cmd = '{cmd_prefix} {command} --attrs-rules ' \
-                        '{attrs_rules}'.format(cmd_prefix=self.prefix,
-                                               command=command,
-                                               attrs_rules=err_attrs_rules)
-        self.invoke(
-            err_labels_cmd,
-            err_str_segment='The labels filter rule `e is`',
-            exception=InvalidLabelsFilterRuleFormat
-        )
+    def _test_providing_invalid_filter_rules(self, command, prefix=None):
+        prefix = prefix or self.prefix
+        invalid_labels_rules = [
+            'ke%y=value',
+            '"key!=val\tue"',
+            '"key&value"',
+            '"key is value"',
+        ]
+        invalid_attrs_rules = invalid_labels_rules + [
+            '"key=val&ue"',
+            '"key=[value"',
+            '"key=[va\\,lue]"',
+        ]
 
-        self.invoke(
-            err_attrs_cmd,
-            err_str_segment='The attributes filter rule `c is`',
-            exception=InvalidAttributesFilterRuleFormat
-        )
+        for labels_rule in invalid_labels_rules:
+            cmd = '{0} {1} -lr {2}'.format(prefix, command, labels_rule)
+            self.invoke(
+                cmd,
+                err_str_segment='labels filter rule `{0}`'.format(
+                    labels_rule.strip('""')),
+                exception=InvalidLabelsFilterRuleFormat
+            )
+
+        for attrs_rule in invalid_attrs_rules:
+            cmd = '{0} {1} -ar {2}'.format(prefix, command, attrs_rule)
+            self.invoke(
+                cmd,
+                err_str_segment='attributes filter rule `{0}`'.format(
+                    attrs_rule.strip('""')),
+                exception=InvalidAttributesFilterRuleFormat
+            )
 
 
 class BlueprintsFiltersTest(FiltersTest):

--- a/cloudify_cli/tests/commands/test_filters.py
+++ b/cloudify_cli/tests/commands/test_filters.py
@@ -81,8 +81,8 @@ class FiltersTest(CliCommandTest):
             'value': [
                 {'key': 'key', 'values': ['va, l\xf3e'], 'operator': 'any_of',
                  'type': 'label'},
-                {'key': 'ke.y', 'values': ['val:$'], 'operator': 'any_of',
-                 'type': 'label'},
+                {'key': 'ke.y', 'values': ['val:$', 'va\xf3lue'],
+                 'operator': 'any_of', 'type': 'label'},
                 {'key': 'created_by', 'values': ['val-u.e'],
                  'operator': 'not_any_of', 'type': 'attribute'}],
             'updated_at': '2021-04-05T15:25:40.310Z',
@@ -94,7 +94,7 @@ class FiltersTest(CliCommandTest):
             'labels_filter_rules': [
                 {'key': 'key', 'values': ['va, l\xf3e'], 'operator': 'any_of',
                  'type': 'label'},
-                {'key': 'ke.y', 'values': ['val:$'],
+                {'key': 'ke.y', 'values': ['val:$', 'va\xf3lue'],
                  'operator': 'any_of', 'type': 'label'}
             ],
             'attrs_filter_rules': [
@@ -143,7 +143,8 @@ class FiltersTest(CliCommandTest):
                          {'sort': 'id', 'is_descending': False,
                           '_all_tenants': False, '_search': None,
                           '_offset': 0, '_size': 1000})
-        self.assertIn('"key=va\\, l\xf3e","ke.y=val\\:\\$"', raw_output)
+        self.assertIn('"key=va\\, l\xf3e","ke.y=[val\\:\\$,va\xf3lue]"',
+                      raw_output)
         self.assertIn('"created_by=val-u.e"', raw_output)
 
     def test_filters_update(self):

--- a/cloudify_cli/tests/commands/test_filters.py
+++ b/cloudify_cli/tests/commands/test_filters.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from mock import MagicMock
 from collections import OrderedDict
 

--- a/cloudify_cli/tests/commands/test_labels.py
+++ b/cloudify_cli/tests/commands/test_labels.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 from mock import Mock
 from collections import OrderedDict

--- a/cloudify_cli/tests/commands/test_labels.py
+++ b/cloudify_cli/tests/commands/test_labels.py
@@ -1,0 +1,227 @@
+import json
+from mock import Mock
+from collections import OrderedDict
+
+from cloudify_rest_client import blueprints, deployments
+
+from cloudify_cli.labels_utils import labels_list_to_set
+from cloudify_cli.cli.cfy import get_formatted_labels_list
+from cloudify_cli.exceptions import (LabelsValidationError,
+                                     CloudifyValidationError)
+
+
+from .test_base import CliCommandTest
+from .constants import SAMPLE_ARCHIVE_PATH
+
+LABELS = [
+    {'key': 'key1', 'value': 'val ue', 'created_at': '1', 'creator_id': 0},
+    {'key': 'key2', 'value': 'val\xf3ue', 'created_at': '2', 'creator_id': 0},
+    {'key': 'key2', 'value': 'val,ue ', 'created_at': '2', 'creator_id': 0},
+]
+
+LABELED_BLUEPRINT = blueprints.Blueprint({
+    'blueprint_id': 'bp1',
+    'labels': LABELS
+})
+
+LABELED_DEPLOYMENT = deployments.Deployment({
+    'deployment_id': 'dep1',
+    'labels': LABELS
+})
+
+
+class LabelsFunctionalityTest(CliCommandTest):
+    __test__ = True
+
+    def setUp(self):
+        super(LabelsFunctionalityTest, self).setUp()
+
+    def test_formatting_labels_list_success(self):
+        matching_labels = OrderedDict([
+                ('3key:value', {'3key': 'value'}),
+                ('key:val ue', {'key': 'val ue'}),
+                ('key:val\\,ue', {'key': 'val,ue'}),
+                ('ke-y:val\\:ue ', {'ke-y': 'val:ue '}),
+                ('k_e.y:12val34. \\,ue', {'k_e.y': '12val34. ,ue'}),
+                (' key:val\xf3u\\:e', {'key': 'val\xf3u:e'})])
+
+        labels_str = ','.join(matching_labels.keys())
+        formatted_labels_list = get_formatted_labels_list(labels_str)
+        self.assertEqual(formatted_labels_list, list(matching_labels.values()))
+
+    def test_null_label_fails(self):
+        with self.assertRaisesRegex(CloudifyValidationError, 'contain null'):
+            get_formatted_labels_list('key:val\x00ue')
+
+    def test_invalid_label_key_fails(self):
+        with self.assertRaisesRegex(LabelsValidationError, 'key contains'):
+            get_formatted_labels_list('ke&y:value')
+
+    def test_invalid_label_value_fails(self):
+        with self.assertRaisesRegex(LabelsValidationError, 'value contains'):
+            get_formatted_labels_list('key:val"ue')
+
+    def test_no_colons_in_labels_fails(self):
+        with self.assertRaisesRegex(LabelsValidationError, 'form <key>'):
+            get_formatted_labels_list('key-value')
+
+    def test_multiple_colons_in_labels_fails(self):
+        with self.assertRaisesRegex(LabelsValidationError, 'form <key>'):
+            get_formatted_labels_list('key:val:ue')
+
+    def test_missing_label_key_fails(self):
+        with self.assertRaisesRegex(LabelsValidationError, 'form <key>'):
+            get_formatted_labels_list(':value')
+
+    def test_missing_label_value_fails(self):
+        with self.assertRaisesRegex(LabelsValidationError, 'form <key>'):
+            get_formatted_labels_list('key:')
+
+
+class LabelsTest(CliCommandTest):
+    __test__ = False
+
+    def setUp(self, resource, create_resource_cmd):
+        super(LabelsTest, self).setUp()
+        self.use_manager()
+        self.create_resource_cmd = create_resource_cmd
+        self.labels_cmd = 'cfy ' + resource + ' labels'
+
+    def test_resource_create_failure_with_invalid_labels(self):
+        self.invoke(self.create_resource_cmd + ' --labels key:',
+                    err_str_segment='form <key>',
+                    exception=LabelsValidationError)
+
+        self.invoke(self.create_resource_cmd + ' --labels "key:val\tue"',
+                    err_str_segment='value contains',
+                    exception=LabelsValidationError)
+
+        self.invoke(self.create_resource_cmd + ' --labels ke&y:value',
+                    err_str_segment='key contains',
+                    exception=LabelsValidationError)
+
+    def test_resource_labels_delete_failure_with_invalid_label(self):
+        self.invoke(
+            self.labels_cmd + ' delete key1:val1,key2:val2 res',
+            err_str_segment='<key>:<value> or <key>',
+            exception=CloudifyValidationError)
+
+        self.invoke(self.labels_cmd + ' delete ke&y res',
+                    err_str_segment='key contains illegal',
+                    exception=LabelsValidationError)
+
+        self.invoke(self.labels_cmd + ' delete key:"val\tue" res',
+                    err_str_segment='value contains',
+                    exception=LabelsValidationError)
+
+        self.invoke(self.labels_cmd + ' delete :value res',
+                    err_str_segment='form <key>',
+                    exception=LabelsValidationError)
+
+
+class DeploymentsLabelsTest(LabelsTest):
+    __test__ = True
+
+    def setUp(self):
+        super(DeploymentsLabelsTest, self).setUp(
+            'deployments',
+            'cfy deployments create -b bp1 dep1')
+
+    def test_deployment_create_with_labels(self):
+        self.client.deployments.create = Mock()
+        self.invoke('cfy deployments create -b bp1 dep1 '
+                    '--labels key1:val1,key2:val2')
+        call_args = list(self.client.deployments.create.call_args)
+        self.assertEqual(call_args[1]['labels'],
+                         [{'key1': 'val1'}, {'key2': 'val2'}])
+
+    def test_deployment_labels_list(self):
+        self.client.deployments.get = Mock(return_value=LABELED_DEPLOYMENT)
+        raw_outcome = self.invoke('cfy deployments labels list dep1 --json')
+        labels = json.loads(raw_outcome.output)
+        self.assertEqual(labels,  {'key1': ['val ue'],
+                                   'key2': ['val\xf3ue', 'val,ue ']})
+
+    def test_deployment_labels_add(self):
+        self.client.deployments.get = Mock(return_value=LABELED_DEPLOYMENT)
+        self.client.deployments.update_labels = Mock()
+        self.invoke('cfy deployments labels add '
+                    'key1:"val ue",key2:"value ",key3:"val\\:" dep1')
+        call_args = list(self.client.deployments.update_labels.call_args)
+        self.assertEqual(labels_list_to_set(call_args[0][1]),
+                         labels_list_to_set([{'key1': 'val ue'},
+                                             {'key2': 'value '},
+                                             {'key2': 'val\xf3ue'},
+                                             {'key2': 'val,ue '},
+                                             {'key3': 'val:'}]))
+
+    def test_resource_labels_delete_label(self):
+        self.client.deployments.get = Mock(return_value=LABELED_DEPLOYMENT)
+        self.client.deployments.update_labels = Mock()
+        self.invoke('cfy deployments labels delete key2:"val\\,ue " dep1')
+        call_args = list(self.client.deployments.update_labels.call_args)
+        self.assertEqual(labels_list_to_set(call_args[0][1]),
+                         labels_list_to_set([{'key1': 'val ue'},
+                                             {'key2': 'val\xf3ue'}]))
+
+    def test_deployment_labels_delete_key(self):
+        self.client.deployments.get = Mock(return_value=LABELED_DEPLOYMENT)
+        self.client.deployments.update_labels = Mock()
+        self.invoke('cfy deployments labels delete key2 dep1')
+        call_args = list(self.client.deployments.update_labels.call_args)
+        self.assertEqual(call_args[0][1], [{'key1': 'val ue'}])
+
+
+class BlueprintsLabelsTest(LabelsTest):
+    __test__ = True
+
+    def setUp(self):
+        super(BlueprintsLabelsTest, self).setUp(
+            'blueprints',
+            'cfy blueprints upload {0} -b bp1 '.format(SAMPLE_ARCHIVE_PATH))
+
+    def test_blueprint_upload_with_labels(self):
+        self.client.license.check = Mock()
+        self.mock_wait_for_blueprint_upload(False)
+        cmd = 'cfy blueprints upload {0} -b bp1 '.format(SAMPLE_ARCHIVE_PATH)
+        self.client.blueprints.upload = Mock()
+        self.invoke(cmd + '--labels key1:val1,key2:val2')
+        call_args = list(self.client.blueprints.upload.call_args)
+        self.assertEqual(call_args[1]['labels'],
+                         [{'key1': 'val1'}, {'key2': 'val2'}])
+
+    def test_blueprint_labels_list(self):
+        self.client.blueprints.get = Mock(return_value=LABELED_BLUEPRINT)
+        raw_outcome = self.invoke('cfy blueprints labels list bp1 --json')
+        labels = json.loads(raw_outcome.output)
+        self.assertEqual(labels, {'key1': ['val ue'],
+                                  'key2': ['val\xf3ue', 'val,ue ']})
+
+    def test_blueprint_labels_add(self):
+        self.client.blueprints.get = Mock(return_value=LABELED_BLUEPRINT)
+        self.client.blueprints.update = Mock()
+        self.invoke('cfy blueprints labels add '
+                    'key1:"val ue",key2:"value ",key3:"val\\:" bp1')
+        call_args = list(self.client.blueprints.update.call_args)
+        self.assertEqual(labels_list_to_set(call_args[0][1]['labels']),
+                         labels_list_to_set([{'key1': 'val ue'},
+                                             {'key2': 'value '},
+                                             {'key2': 'val\xf3ue'},
+                                             {'key2': 'val,ue '},
+                                             {'key3': 'val:'}]))
+
+    def test_blueprint_labels_delete_label(self):
+        self.client.blueprints.get = Mock(return_value=LABELED_BLUEPRINT)
+        self.client.blueprints.update = Mock()
+        self.invoke('cfy blueprints labels delete key2:"val\\,ue " bp1')
+        call_args = list(self.client.blueprints.update.call_args)
+        self.assertEqual(labels_list_to_set(call_args[0][1]['labels']),
+                         labels_list_to_set([{'key1': 'val ue'},
+                                             {'key2': 'val\xf3ue'}]))
+
+    def test_blueprint_labels_delete_key(self):
+        self.client.blueprints.get = Mock(return_value=LABELED_BLUEPRINT)
+        self.client.blueprints.update = Mock()
+        self.invoke('cfy blueprints labels delete key2 bp1')
+        call_args = list(self.client.blueprints.update.call_args)
+        self.assertEqual(call_args[0][1]['labels'], [{'key1': 'val ue'}])

--- a/cloudify_cli/tests/commands/test_labels.py
+++ b/cloudify_cli/tests/commands/test_labels.py
@@ -50,7 +50,7 @@ class LabelsFunctionalityTest(CliCommandTest):
         self.assertEqual(formatted_labels_list, list(matching_labels.values()))
 
     def test_null_label_fails(self):
-        with self.assertRaisesRegex(CloudifyValidationError, 'contain null'):
+        with self.assertRaisesRegex(CloudifyValidationError, 'control char'):
             get_formatted_labels_list('key:val\x00ue')
 
     def test_invalid_label_key_fails(self):
@@ -58,7 +58,7 @@ class LabelsFunctionalityTest(CliCommandTest):
             get_formatted_labels_list('ke&y:value')
 
     def test_invalid_label_value_fails(self):
-        with self.assertRaisesRegex(LabelsValidationError, 'value contains'):
+        with self.assertRaisesRegex(CloudifyValidationError, 'control char'):
             get_formatted_labels_list('key:val"ue')
 
     def test_no_colons_in_labels_fails(self):
@@ -93,8 +93,8 @@ class LabelsTest(CliCommandTest):
                     exception=LabelsValidationError)
 
         self.invoke(self.create_resource_cmd + ' --labels "key:val\tue"',
-                    err_str_segment='value contains',
-                    exception=LabelsValidationError)
+                    err_str_segment='control char',
+                    exception=CloudifyValidationError)
 
         self.invoke(self.create_resource_cmd + ' --labels ke&y:value',
                     err_str_segment='key contains',
@@ -111,8 +111,8 @@ class LabelsTest(CliCommandTest):
                     exception=LabelsValidationError)
 
         self.invoke(self.labels_cmd + ' delete key:"val\tue" res',
-                    err_str_segment='value contains',
-                    exception=LabelsValidationError)
+                    err_str_segment='control char',
+                    exception=CloudifyValidationError)
 
         self.invoke(self.labels_cmd + ' delete :value res',
                     err_str_segment='form <key>',


### PR DESCRIPTION
If we want to allow special characters in labels, we need to modify the way they are currently provided in the CLI. This PR includes a few changes:

- Modifying the way we parse a provided labels list. This PR allows passing special characters in labels' values, where `,` and `:` must be escaped with `\`. 
- Modifying the way a user supplies filter rules. Following this PR, instead of supplying a string of filter rules separated by an ` and `, the user supplies each filter rule separately. This is done because I couldn't figure out a nice way to separate the big string of filter rules. 
- Moreover, the filter rules will be parsed using regular expressions to make sure we capture the right parts of each filter rule.

Associated PR: https://github.com/cloudify-cosmo/cloudify-manager/pull/2847