### PR TITLE
RD-1908 Use patched sudo version 1.9.6

### DIFF
--- a/packaging/docker_builder/Dockerfile
+++ b/packaging/docker_builder/Dockerfile
@@ -15,4 +15,4 @@ RUN /bin/bash -c '''\
     gem install ohai -v 14.8.12 --no-document && \
     gem install omnibus -v 6.1.4 --no-document \
 '''
-RUN yum install sudo -y
+RUN yum install https://github.com/sudo-project/sudo/releases/download/SUDO_1_9_6p1/sudo-1.9.6-2.el6.x86_64.rpm -y


### PR DESCRIPTION
Because of https://nvd.nist.gov/vuln/detail/CVE-2021-3156, let's use patched `sudo` RPM published by https://www.sudo.ws/.