### PR TITLE
RD-1923 Change labels delete implementation

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -247,14 +247,7 @@ def parse_and_validate_label_to_delete(ctx, param, value):
         raise CloudifyValidationError(
             'ERROR: The `{0}` argument is empty'.format(param.name))
 
-    labels_list = get_formatted_labels_list(value, allow_only_key=True)
-    if len(labels_list) > 1:
-        raise CloudifyValidationError(
-            'LABEL can be either <key>:<value> or <key>')
-    [(label_key, label_value)] = labels_list[0].items()
-    if label_value:
-        return labels_list[0]
-    return label_key
+    return get_formatted_labels_list(value, allow_only_key=True)
 
 
 def get_formatted_labels_list(raw_labels_string, allow_only_key=False):
@@ -284,7 +277,8 @@ def get_formatted_labels_list(raw_labels_string, allow_only_key=False):
         else:
             if allow_only_key:
                 raise CloudifyValidationError(
-                    'LABEL can be either <key>:<value> or <key>')
+                    'LABEL should be a mixed list of labels and keys. I.e. '
+                    '<key>:<value>,<key>,<key>:<value>')
             raise LabelsValidationError(label, format_err_msg)
 
         label_key = label_key.replace('\x00', ':').strip()

--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -606,8 +606,10 @@ def delete_blueprint_labels(label,
                             client,
                             tenant_name):
     """
-    LABEL: Can be either <key>:<value> or <key>. If <key> is provided,
+    LABEL: A mixed list of labels and keys, i.e.
+    <key>:<value>,<key>,<key>:<value>. If <key> is provided,
     all labels associated with this key will be deleted from the deployment.
+    Any comma and colon in <value> must be escaped with `\\`
     """
     delete_labels(blueprint_id, 'blueprint', client.blueprints, label,
                   logger, tenant_name)

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -916,8 +916,10 @@ def delete_deployment_labels(label,
                              client,
                              tenant_name):
     """
-    LABEL: Can be either <key>:<value> or <key>. If <key> is provided,
+    LABEL: A mixed list of labels and keys, i.e.
+    <key>:<value>,<key>,<key>:<value>. If <key> is provided,
     all labels associated with this key will be deleted from the deployment.
+    Any comma and colon in <value> must be escaped with `\\`
     """
     delete_labels(deployment_id, 'deployment', client.deployments, label,
                   logger, tenant_name)

--- a/cloudify_cli/labels_utils.py
+++ b/cloudify_cli/labels_utils.py
@@ -96,7 +96,7 @@ def add_labels(resource_id,
 def delete_labels(resource_id,
                   resource_name,
                   resource_client,
-                  label,
+                  labels_list,
                   logger,
                   tenant_name):
     explicit_tenant_name_message(tenant_name, logger)
@@ -105,17 +105,22 @@ def delete_labels(resource_id,
 
     updated_labels = []
     labels_to_delete = []
-    if isinstance(label, dict):
-        if label in resource_labels:
-            labels_to_delete = [label]
-            resource_labels.remove(label)
-            updated_labels = resource_labels
-    else:  # A label key was provided
-        for resource_label in resource_labels:
-            if label in resource_label:
-                labels_to_delete.append(resource_label)
-            else:
-                updated_labels.append(resource_label)
+    keys_to_delete = set()
+    for label in labels_list:
+        [(key, value)] = label.items()
+        if value:
+            if label in resource_labels:
+                resource_labels.remove(label)
+                labels_to_delete.append(label)
+        else:  # key was provided
+            keys_to_delete.add(key)
+
+    for resource_label in resource_labels:
+        [(key, value)] = resource_label.items()
+        if key in keys_to_delete:
+            labels_to_delete.append(resource_label)
+        else:
+            updated_labels.append(resource_label)
 
     if labels_to_delete:
         if resource_name == 'deployment':

--- a/cloudify_cli/tests/commands/test_labels.py
+++ b/cloudify_cli/tests/commands/test_labels.py
@@ -104,8 +104,8 @@ class LabelsTest(CliCommandTest):
 
     def test_resource_labels_delete_failure_with_invalid_label(self):
         self.invoke(
-            self.labels_cmd + ' delete key1:val1,key2:val2 res',
-            err_str_segment='<key>:<value> or <key>',
+            self.labels_cmd + ' delete key1:val1:val2 res',
+            err_str_segment='labels and keys',
             exception=CloudifyValidationError)
 
         self.invoke(self.labels_cmd + ' delete ke&y res',
@@ -160,18 +160,11 @@ class DeploymentsLabelsTest(LabelsTest):
     def test_resource_labels_delete_label(self):
         self.client.deployments.get = Mock(return_value=LABELED_DEPLOYMENT)
         self.client.deployments.update_labels = Mock()
-        self.invoke('cfy deployments labels delete key2:"val\\,ue " dep1')
+        self.invoke('cfy deployments labels delete '
+                    '"key2:val\\,ue ,key1,key3,key4:value" bp1')
         call_args = list(self.client.deployments.update_labels.call_args)
         self.assertEqual(labels_list_to_set(call_args[0][1]),
-                         labels_list_to_set([{'key1': 'val ue'},
-                                             {'key2': 'val\xf3ue'}]))
-
-    def test_deployment_labels_delete_key(self):
-        self.client.deployments.get = Mock(return_value=LABELED_DEPLOYMENT)
-        self.client.deployments.update_labels = Mock()
-        self.invoke('cfy deployments labels delete key2 dep1')
-        call_args = list(self.client.deployments.update_labels.call_args)
-        self.assertEqual(call_args[0][1], [{'key1': 'val ue'}])
+                         labels_list_to_set([{'key2': 'val\xf3ue'}]))
 
 
 class BlueprintsLabelsTest(LabelsTest):
@@ -212,18 +205,11 @@ class BlueprintsLabelsTest(LabelsTest):
                                              {'key2': 'val,ue '},
                                              {'key3': 'val:'}]))
 
-    def test_blueprint_labels_delete_label(self):
+    def test_blueprint_labels_delete_labels(self):
         self.client.blueprints.get = Mock(return_value=LABELED_BLUEPRINT)
         self.client.blueprints.update = Mock()
-        self.invoke('cfy blueprints labels delete key2:"val\\,ue " bp1')
+        self.invoke('cfy blueprints labels delete '
+                    '"key2:val\\,ue ,key1,key3,key4:value" bp1')
         call_args = list(self.client.blueprints.update.call_args)
         self.assertEqual(labels_list_to_set(call_args[0][1]['labels']),
-                         labels_list_to_set([{'key1': 'val ue'},
-                                             {'key2': 'val\xf3ue'}]))
-
-    def test_blueprint_labels_delete_key(self):
-        self.client.blueprints.get = Mock(return_value=LABELED_BLUEPRINT)
-        self.client.blueprints.update = Mock()
-        self.invoke('cfy blueprints labels delete key2 bp1')
-        call_args = list(self.client.blueprints.update.call_args)
-        self.assertEqual(call_args[0][1]['labels'], [{'key1': 'val ue'}])
+                         labels_list_to_set([{'key2': 'val\xf3ue'}]))


### PR DESCRIPTION
Following a recent change we did to the labels' implementation to the CLI, https://github.com/cloudify-cosmo/cloudify-cli/pull/1264, we can now allow users to delete labels from a deployment by specifying a mixed list of labels and keys. 