### PR TITLE
RD-2068 Fix delete sanity deployment with external db

### DIFF
--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -550,7 +550,7 @@ def manager_delete(deployment_id, force, with_logs, logger, client,
             client, deployment_id, DELETE_DEP)
         if execution:
             execution_events_fetcher.wait_for_execution(
-                client, execution, timeout=18, logger=logger)
+                client, execution, timeout=90, logger=logger)
 
     except ExecutionTimeoutError:
         raise CloudifyCliError(

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,11 @@ setup(
         'backports.shutil_get_terminal_size==1.0.0',
         'ipaddress==1.0.23',
         'setuptools<=40.7.3',
-        'fabric==2.5.0'
+        'cryptography==3.3.2',
+        # Fabric depend on paramiko that depends on cryptography so we need
+        # to install the correct version of cryptography before installing
+        # the fabric so that fabric can be installed correctly in both py2 +
+        # py3
+        'fabric==2.5.0',
     ]
 )


### PR DESCRIPTION
We should increase the timeout to allow the `delete_deployment_environment` workflow to finish when working with external DB.