### PR TITLE
RD-2141 Add deployments display name

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -250,6 +250,17 @@ def parse_and_validate_label_to_delete(ctx, param, value):
     return get_formatted_labels_list(value, allow_only_key=True)
 
 
+def validate_value_not_empty(ctx, param, value):
+    if value is None or ctx.resilient_parsing:
+        return
+
+    if not value:
+        raise CloudifyValidationError(
+            'ERROR: The `{0}` argument is empty'.format(param.name))
+
+    return value
+
+
 def get_formatted_labels_list(raw_labels_string, allow_only_key=False):
     labels_list = []
     if any(unicodedata.category(char)[0] == 'C' or char == '"'
@@ -1732,6 +1743,26 @@ class Options(object):
             '--filter-id',
             callback=validate_name,
             help=helptexts.FILTER_ID
+        )
+
+        self.generate_id = click.option(
+            '--generate-id',
+            is_flag=True,
+            default=False,
+            help=helptexts.GENERATE_ID
+        )
+
+        self.display_name = click.option(
+            '-n',
+            '--display-name',
+            callback=validate_value_not_empty,
+            help=helptexts.DISPLAY_NAME
+        )
+
+        self.search_name = click.option(
+            '--search-name',
+            callback=validate_value_not_empty,
+            help=helptexts.SEARCH_NAME
         )
 
     def common_options(self, f):

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -209,7 +209,7 @@ IMPORT_SSH_KEYS = 'WARNING: Import exported keys to their original locations'
 
 SORT_BY = "Key for sorting the list"
 DESCENDING = "Sort list in descending order [default: False]"
-SEARCH = 'Search resources by name/id. The returned list will include only ' \
+SEARCH = 'Search resources by id. The returned list will include only ' \
          'resources that contain the given search pattern'
 
 TENANT = 'The name of the tenant'
@@ -543,3 +543,13 @@ DEP_GROUP_INTO_ENVIRONMENTS = 'Add created deployments to the environments ' \
                               'already existing in this group.'
 GROUP_ID_FILTER = 'Show only results belonging to this group'
 DELETE_GROUP_DEPLOYMENTS = 'Delete all deployments belonging to this group'
+
+GENERATE_ID = 'Generate a UUID to serve as the deployment ID. This flag ' \
+              'cannot be provided if a deployment ID is specified'
+
+DISPLAY_NAME = 'The display name of the deployment. If not specified, ' \
+               'the deployment ID will be used instead.'
+
+SEARCH_NAME = 'Search deployments by their display name. The returned list ' \
+              'will include only deployments that contain the given search ' \
+              'pattern'

--- a/cloudify_cli/tests/commands/test_deployments.py
+++ b/cloudify_cli/tests/commands/test_deployments.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 ############
 
+from __future__ import unicode_literals
+
 
 import json
 import inspect

--- a/cloudify_cli/tests/commands/test_deployments.py
+++ b/cloudify_cli/tests/commands/test_deployments.py
@@ -19,6 +19,7 @@ import json
 import inspect
 import datetime
 import warnings
+from uuid import UUID
 
 from mock import patch, MagicMock, PropertyMock, Mock
 
@@ -723,6 +724,43 @@ class DeploymentsTest(CliCommandTest):
                     break
             self.assertTrue(found, 'String ''{0}'' not found in outcome {1}'
                             .format(output, outcome))
+
+    def test_create_deployment_with_display_name(self):
+        dep_display_name = 'Depl\xf3yment'
+        self.client.deployments.create = Mock()
+        self.invoke('cfy deployments create -b bp1 -n {0} '
+                    'dep1'.format(dep_display_name))
+        call_args = list(self.client.deployments.create.call_args)
+        self.assertEqual(call_args[1]['display_name'], dep_display_name)
+
+    def test_create_deployment_display_name_defaults_to_id(self):
+        dep_id = 'dep1'
+        self.client.deployments.create = Mock()
+        self.invoke('cfy deployments create -b bp1 {0}'.format(dep_id))
+        call_args = list(self.client.deployments.create.call_args)
+        self.assertEqual(call_args[1]['display_name'], dep_id)
+
+    def test_create_deployment_with_generated_id(self):
+        self.client.deployments.create = Mock()
+        self.invoke('cfy deployments create -b bp1 --generate-id')
+        call_args = list(self.client.deployments.create.call_args)
+        try:
+            UUID(call_args[0][1], version=4)
+        except ValueError:
+            raise Exception('The deployment was not created with a valid UUID')
+
+    def test_create_deployment_with_id_and_generate_id_fails(self):
+        self.invoke('cfy deployments create -b bp1 --generate-id dep1',
+                    err_str_segment='cannot be provided',
+                    exception=CloudifyCliError)
+
+    def test_list_deployments_with_search_name(self):
+        search_name_pattern = 'De#pl\xf3yment 1'
+        self.client.deployments.list = Mock(return_value=MockListResponse())
+        self.invoke('cfy deployments list --search-name '
+                    '"{0}"'.format(search_name_pattern))
+        call_args = list(self.client.deployments.list.call_args)
+        self.assertEqual(call_args[1].get('_search_name'), search_name_pattern)
 
 
 class DeploymentModificationsTest(CliCommandTest):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 wheel==0.29.0
 setuptools==40.7.3
 virtualenv==15.1.0
-https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip#egg=cloudify-common[dispatcher]
+https://github.com/cloudify-cosmo/cloudify-common/archive/RD-2140-add-deployments-display-name-to-rest.zip#egg=cloudify-common[dispatcher]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 wheel==0.29.0
 setuptools==40.7.3
 virtualenv==15.1.0
-https://github.com/cloudify-cosmo/cloudify-common/archive/RD-2140-add-deployments-display-name-to-rest.zip#egg=cloudify-common[dispatcher]
+https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip#egg=cloudify-common[dispatcher]


### PR DESCRIPTION
This PR implements the following:

- Adding display name to deployments create.
- Adding `--generate-id` to deployments create.
- Adding `--search-name` to deployments list.