### PR TITLE
RD-2287 deployment group deploy-on: new ids and naming

### DIFF
--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -1155,11 +1155,19 @@ def groups_extend(deployment_group_name, deployment_id, count, filter_id,
                   client, logger):
     new_deployments = []
     if environments_group:
+        deployment_group = client.deployment_groups.get(deployment_group_name)
         for deployment in client.deployments.list(
                 deployment_group_id=environments_group):
             if deployment.is_environment():
-                new_deployments.append(
-                    {'labels': [{'csys-environment': deployment.id}]})
+                new_id = str(uuid.uuid4())
+                new_deployments.append({
+                    'id': new_id,
+                    'display_name': "{blueprint_id}-{uuid}".format(
+                        blueprint_id=deployment_group.default_blueprint_id,
+                        uuid=new_id,
+                    ),
+                    'labels': [{'csys-obj-parent': deployment.id}],
+                })
     group = client.deployment_groups.add_deployments(
         deployment_group_name,
         filter_id=filter_id,


### PR DESCRIPTION
* Use UUID4 for deployment.ids "deployed-on"

Force the new deployments created with "deploy-on" mechanism (a.k.a.
"into environments") have ids populated using UUID4 instead of a
template <environment>-<blueprint_id>-<uuid>.  The former solution might
have had caused excesively long deployment ids, especially in case of
multiple levels of environments, sub-environments (and services).

* Populate display_name for new deployments

* Populate `csys-obj-parent` the same `csys-environment` used to be populated