### PR TITLE
exec group start: add a log showing the exec-group id

### DIFF
--- a/cloudify_cli/commands/executions.py
+++ b/cloudify_cli/commands/executions.py
@@ -651,6 +651,10 @@ def execution_groups_start(deployment_group, workflow_id, parameters,
         force=force,
         concurrency=concurrency,
     )
+    logger.info('Execution group %s started: running %s on '
+                'deployment group %s [concurrency=%s]',
+                group.id, group.workflow_id, group.deployment_group_id,
+                group.concurrency)
     try:
         execution = wait_for_execution_group(client, group,
                                              events_handler=events_logger,


### PR DESCRIPTION
The id is useful to have, I dont want to check `cfy exe gro li` every
time to find it