### PR TITLE
RD-2485 wait_for_blueprint: refetch the bp before returning

### DIFF
--- a/cloudify_cli/utils.py
+++ b/cloudify_cli/utils.py
@@ -465,6 +465,6 @@ def wait_for_blueprint_upload(client, blueprint_id, logging_level):
             break
 
         time.sleep(WAIT_FOR_BLUEPRINT_UPLOAD_SLEEP_INTERVAL)
-
+    blueprint = client.blueprints.get(blueprint_id)
     _handle_errors()
     return blueprint


### PR DESCRIPTION
This ports #1313 to 5.2.3.

We want the blueprint state from AFTER the workflow finished, so we
must refetch it.

I note that the blueprint can be in an _intermediary_ failed state,
and then a retry (in the workflow) would save it. That's ugly and
we should probably change that, but for now, no need to return an
intermediary state to the user. Let's return the final state instead.

FWIW, the "retries" that save it happen in case of a cluster, where
the workflow sends a request to a restservice node who does not have
the blueprint, that restservice sets the blueprint state (ugly!),
and then the workflow (by using the cluster client) retries with
another restservice node, and then continues correctly.