### PR TITLE
test_manager_offline: mock requests.Session

### DIFF
--- a/cloudify_cli/tests/test_env.py
+++ b/cloudify_cli/tests/test_env.py
@@ -1187,8 +1187,7 @@ class TestClusterRestClient(CliCommandTest):
 
             self.fail('Unexpected url: {0}'.format(request_url))
 
-        return mock.patch('cloudify_rest_client.client.requests.get',
-                          side_effect=_mocked_get)
+        return mock.patch('requests.Session.get', side_effect=_mocked_get)
 
     def test_manager_offline(self):
         env.profile.manager_ip = '127.0.0.1'


### PR DESCRIPTION
Ever since cloudify-cosmo/cloudify-common#795 we don't use raw
requests.get anymore, but create an explicit requests.Session.
So the mock that mocked requests.get, needs to be updated.