### PR TITLE
RD-2587 optimize qos

### DIFF
--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -2,6 +2,12 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
+  - name: jnlp
+    image: jenkins/inbound-agent:4.3-4
+    resources:
+      limits:
+        cpu: 0.3
+        memory: 256Mi
   - name: py36
     image: circleci/python:3.6
     resources:

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -6,11 +6,11 @@ spec:
     image: circleci/python:3.6
     resources:
       requests:
-        cpu: 0.3
-        memory: 512Mi
+        cpu: 0.8
+        memory: 1Gi
       limits:
-        cpu: 1.5
-        memory: 512Mi
+        cpu: 2.5
+        memory: 2Gi
     command:
     - cat
     tty: true
@@ -27,11 +27,11 @@ spec:
       privileged: true
     resources:
       requests:
-        cpu: 0.4
-        memory: 512Mi
+        cpu: 0.8
+        memory: 1Gi
       limits:
-        cpu: 1.5
-        memory: 512Mi
+        cpu: 2.5
+        memory: 2Gi
   - name: py27
     image: circleci/python:2.7
     command:
@@ -42,11 +42,11 @@ spec:
       privileged: true
     resources:
       requests:
-        cpu: 0.3
-        memory: 512Mi
+        cpu: 0.8
+        memory: 1Gi
       limits:
-        cpu: 1.5
-        memory: 512Mi
+        cpu: 2.5
+        memory: 2Gi
   - name: debbuild
     image: ubuntu:18.04
     command:
@@ -57,11 +57,11 @@ spec:
       privileged: true
     resources:
       requests:
-        cpu: 0.4
-        memory: 512Mi
+        cpu: 0.8
+        memory: 1Gi
       limits:
-        cpu: 1.5
-        memory: 512Mi
+        cpu: 2.5
+        memory: 2Gi
   - name: awscli
     image: amazon/aws-cli
     command:
@@ -74,4 +74,4 @@ spec:
   imagePullSecrets:
     - name: dockerhub
   nodeSelector:
-    instance-type: spot
+    instance-type: spot-xlarge

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -6,7 +6,11 @@ spec:
     image: circleci/python:3.6
     resources:
       requests:
+        cpu: 0.3
+        memory: 512Mi
+      limits:
         cpu: 1
+        memory: 512Mi
     command:
     - cat
     tty: true
@@ -21,17 +25,28 @@ spec:
     securityContext:
       runAsUser: 0
       privileged: true
-  - name: py27
-    image: circleci/python:2.7
     resources:
       requests:
-        cpu: 0.6
+        cpu: 0.4
+        memory: 512Mi
+      limits:
+        cpu: 1
+        memory: 512Mi
+  - name: py27
+    image: circleci/python:2.7
     command:
     - cat
     tty: true
     securityContext:
       runAsUser: 0
       privileged: true
+    resources:
+      requests:
+        cpu: 0.3
+        memory: 512Mi
+      limits:
+        cpu: 1
+        memory: 512Mi
   - name: debbuild
     image: ubuntu:18.04
     command:
@@ -40,6 +55,13 @@ spec:
     securityContext:
       runAsUser: 0
       privileged: true
+    resources:
+      requests:
+        cpu: 0.4
+        memory: 512Mi
+      limits:
+        cpu: 1
+        memory: 512Mi
   - name: awscli
     image: amazon/aws-cli
     command:
@@ -52,4 +74,4 @@ spec:
   imagePullSecrets:
     - name: dockerhub
   nodeSelector:
-    instance-type: spot-xlarge
+    instance-type: spot

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -9,7 +9,7 @@ spec:
         cpu: 0.3
         memory: 512Mi
       limits:
-        cpu: 1
+        cpu: 1.5
         memory: 512Mi
     command:
     - cat
@@ -30,7 +30,7 @@ spec:
         cpu: 0.4
         memory: 512Mi
       limits:
-        cpu: 1
+        cpu: 1.5
         memory: 512Mi
   - name: py27
     image: circleci/python:2.7
@@ -45,7 +45,7 @@ spec:
         cpu: 0.3
         memory: 512Mi
       limits:
-        cpu: 1
+        cpu: 1.5
         memory: 512Mi
   - name: debbuild
     image: ubuntu:18.04
@@ -60,7 +60,7 @@ spec:
         cpu: 0.4
         memory: 512Mi
       limits:
-        cpu: 1
+        cpu: 1.5
         memory: 512Mi
   - name: awscli
     image: amazon/aws-cli


### PR DESCRIPTION
Optimized QoS to burstable as some stages run in parallel use different containers.
Using spot NG wasn't enough resources as the tests starved for resources.

Optimizing the QoS keeps the build times about the same but makes sure the build won't choke the resources.