### PR TITLE
RD-3156 Wait for the upload_blueprint execution creation

### DIFF
--- a/cloudify_cli/utils.py
+++ b/cloudify_cli/utils.py
@@ -426,7 +426,7 @@ def wait_for_blueprint_upload(client, blueprint_id, logging_level):
                     blueprint['error_traceback'])
             raise CloudifyCliError(error_msg)
 
-    @retry(stop_max_attempt_number=10, wait_incrementing_start=0)
+    @retry(stop_max_attempt_number=5, wait_fixed=1000)
     def _get_blueprint_and_upload_execution_id():
         bp = client.blueprints.get(blueprint_id)
         # upload_execution['id'] might not be available at first, hence retry


### PR DESCRIPTION
Wait for upload_blueprint execution creation for maximum of about 5
seconds (0ms -> 100ms -> 200ms -> ... -> 900ms).  Sometimes the
execution was not started yet at the time we tried retrieving it's ID.