### PR TITLE
RD-3089 Implement cfy auditlog truncate

### DIFF
--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -559,3 +559,10 @@ AUDIT_CREATOR_NAME = 'Name of a user who introduced changes recorded in the ' \
                      'audit log.'
 AUDIT_EXECUTION_ID = 'ID of an execution which introduced changes recorded ' \
                      'in the audit log.'
+AUDIT_TRUNCATE_BEFORE = 'Truncate audit logs which were stored this long ' \
+                        'ago or earlier.  Can be specified either as the ' \
+                        'difference counted from the current time (e.g. ' \
+                        '6.5h for 6:30 hours ago, 2d - 2 days ago, 7w - 7 '\
+                        'weeks ago), or an ordinary UTC timestamp ' \
+                        '(2021-08-18, 2021-08-18T14:25:36, 2021-08-18 '\
+                        '14:25:36, 2021-08-18 14:25:36.99, @1629296736)'

--- a/cloudify_cli/commands/audit_log.py
+++ b/cloudify_cli/commands/audit_log.py
@@ -82,6 +82,5 @@ def truncate_logs(before,
         params.update({'creator_name': creator_name})
     if execution_id:
         params.update({'execution_id': execution_id})
-    result = client.auditlog.post('truncate', **params)
-    logger.info('%d audit log entries have been truncated',
-                result.processed)
+    result = client.auditlog.delete(**params)
+    logger.info('%d audit log entries have been truncated', result.deleted)


### PR DESCRIPTION
Truncate audit_log entries

```
Options:
  -b, --before TEXT        Truncate audit logs which were stored this long ago
                           or earlier.  Can be specified either as the
                           difference counted from the current time (e.g. 6.5h
                           for 6:30 hours ago, 2d - 2 days ago, 7w - 7 weeks
                           ago), or an ordinary UTC timestamp (2021-08-18,
                           2021-08-18T14:25:36, 2021-08-18 14:25:36,
                           2021-08-18 14:25:36.99, @1629296736)  [required]

  -c, --creator-name TEXT  Name of a user who introduced changes recorded in
                           the audit log.

  -e, --execution-id TEXT  ID of an execution which introduced changes
                           recorded in the audit log.
```