### PR TITLE
Fix the DEB build

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -124,12 +124,6 @@ pipeline {
             sh script: "mkdir -p ${env.WORKSPACE}/project && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/project", label: "copying repo to seperate workspace"
             container('debbuild') {
               sh script: 'mkdir /tmp/result', label: "create result folder"
-              echo 'install python setup tools'
-              sh'''
-                set -ex
-                apt-get update
-                apt-get install python3 python3-setuptools python3-distutils -y
-              '''
               sh script: "/bin/bash ${env.WORKSPACE}/project/packaging/debian/build.sh", label: "build the deb package"
               sh script: """
                 set -ex

--- a/packaging/debian/build.sh
+++ b/packaging/debian/build.sh
@@ -17,7 +17,7 @@ set -xu
 BUILD_DIR=~/cloudify-cli_${CLOUDIFY_VERSION}-${CLOUDIFY_PACKAGE_RELEASE}_amd64
 
 apt-get update
-apt-get install python3 python3-venv git -y
+apt-get install python3 python3-venv git gcc python3-dev -y
 mkdir -p "${BUILD_DIR}/DEBIAN" "${BUILD_DIR}/opt"
 cat >"${BUILD_DIR}/DEBIAN/control" <<EOF
 Package: cloudify


### PR DESCRIPTION
Add gcc and python-dev to the .deb build, so that it can pass.
We need to be able to compile stuff, for some requirements.