### PR TITLE
local: allow listing blueprints even if there's none

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1776,6 +1776,16 @@ class Options(object):
             f = arg(f)
         return f
 
+    def local_common_options(self, f):
+        """A shorthand for applying commonly used arguments for local profiles.
+
+        Similar to common_options, but doesn't apply the options that are only
+        relevant to managers.
+        """
+        for arg in [self.json, self.verbose(), self.format, self.quiet()]:
+            f = arg(f)
+        return f
+
     def parse_comma_separated(self, ctx, param, value):
         """Callback for parsing multiple comma-separated arguments.
 

--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -305,6 +305,7 @@ def manager_list(filter_id,
 
 
 @cfy.command(name='list', short_help='List blueprints')
+@cfy.options.local_common_options
 @cfy.pass_logger
 def local_list(logger):
     blueprints = local.list_blueprints()

--- a/cloudify_cli/local.py
+++ b/cloudify_cli/local.py
@@ -69,7 +69,13 @@ def storage_dir(blueprint_id=None):
 
 def list_blueprints():
     blueprints = []
-    for bp_id in os.listdir(os.path.join(env.PROFILES_DIR, _ENV_NAME)):
+    try:
+        bp_names = os.listdir(os.path.join(env.PROFILES_DIR, _ENV_NAME))
+    except IOError as e:
+        if e.errno != 2:  # file not found
+            raise
+        bp_names = []
+    for bp_id in bp_names:
         bp_env = load_env(bp_id)
         blueprints.append({
             'id': bp_id,

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -92,6 +92,7 @@ pipeline {
               """
               sh script:"""
                 cd ~/rpmbuild/SOURCES
+                yum update -y
                 yum install rpmdevtools -y
                 yum-builddep -y packaging/cloudify-cli.spec
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
               sh script:"""
                 cd ~/rpmbuild/SOURCES
                 yum install rpmdevtools -y
-                for i in {1..30}; do yum-builddep -y packaging/cloudify-cli.spec && break || sleep 10; done
+                yum-builddep -y packaging/cloudify-cli.spec
 
                 spectool \
                   -d "CLOUDIFY_VERSION ${env.CLOUDIFY_VERSION}" \


### PR DESCRIPTION
I just did `cfy prof use local` and `cfy blu li` and was greeted with
an error. I expected to see an empty list instead.
So this makes it be an empty blueprints list indeed.