### PR TITLE
local: allow listing blueprints even if there's none (#1334)

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -92,8 +92,9 @@ pipeline {
               """
               sh script:"""
                 cd ~/rpmbuild/SOURCES
+                yum update -y
                 yum install rpmdevtools -y
-                for i in {1..30}; do yum-builddep -y packaging/cloudify-cli.spec && break || sleep 10; done
+                yum-builddep -y packaging/cloudify-cli.spec
 
                 spectool \
                   -d "CLOUDIFY_VERSION ${env.CLOUDIFY_VERSION}" \


### PR DESCRIPTION
* Implement local_common_options

Like common_options but sans --manager

* local `cfy blu li`: don't break if no local profile

this directory won't exist if no local blueprint was initialized
yet. In that case, just return the empty list, as opposed to breaking
with a file not found error.

* jenkinsfile: drop the retry loop

i dont see a reason to have it

* jenkinsfile: add a `yum update -y`

allegedly it might help