### PR TITLE
auditlog before/since: move parsing to the server side

### DIFF
--- a/cloudify_cli/commands/audit_log.py
+++ b/cloudify_cli/commands/audit_log.py
@@ -13,7 +13,8 @@ AUDITLOG_COLUMNS = ['ref_table', 'ref_id', 'operation', 'creator_name',
                     'execution_id', 'created_at']
 
 
-def to_utc_timestamp(spec):
+def _parse_before(spec):
+    """Parse the --before/--since parameter"""
     r = re.match(r'^([.\d]+)([hdw])$', spec, re.IGNORECASE)
     if r:
         # timestamp specification e.g. 10.5h, 15d, 7w
@@ -77,7 +78,7 @@ def list_logs(creator_name,
               logger,
               client,
               ):
-    since_timestamp = to_utc_timestamp(since) if since else None
+    since_timestamp = _parse_before(since) if since else None
     if follow:
         if PY2:
             raise CloudifyCliError('Streaming requires Python>=3.6.')
@@ -143,7 +144,7 @@ def truncate_logs(before,
                   client
                   ):
     """Truncate audit_log entries"""
-    before_timestamp = to_utc_timestamp(before)
+    before_timestamp = _parse_before(before)
     if before_timestamp is None:
         raise CloudifyCliError('Failed to parse timestamp: {0}'
                                .format(before))

--- a/cloudify_cli/commands/audit_log.py
+++ b/cloudify_cli/commands/audit_log.py
@@ -33,12 +33,7 @@ def _parse_before(ctx, spec):
           raise CloudifyCliError('Failed to parse timestamp: {0}'
                                  .format(before))
     else:
-        for fmt in ['%Y-%m-%dT%H:%M:%S.%f', '%Y-%m-%d %H:%M:%S.%f',
-                    '%Y-%m-%dT%H:%M:%S', '%Y-%m-%d %H:%M:%S', '%Y-%m-%d']:
-            try:
-                return datetime.strptime(spec, fmt)
-            except ValueError:
-                pass
+        return spec
 
 
 @cfy.group(name='auditlog')

--- a/cloudify_cli/utils.py
+++ b/cloudify_cli/utils.py
@@ -28,11 +28,9 @@ import tarfile
 import zipfile
 import tempfile
 import collections
-import re
 from shutil import copy
 from contextlib import closing, contextmanager
 from backports.shutil_get_terminal_size import get_terminal_size
-from datetime import datetime, timedelta
 
 import yaml
 import requests
@@ -481,29 +479,3 @@ def wait_for_blueprint_upload(client, blueprint_id, logging_level):
     blueprint = client.blueprints.get(blueprint_id)
     _handle_errors()
     return blueprint
-
-
-def to_utc_timestamp(spec):
-    r = re.match(r'^([.\d]+)([hdw])$', spec, re.IGNORECASE)
-    if r:
-        # timestamp specification e.g. 10.5h, 15d, 7w
-        count, unit = float(r.groups()[0]), r.groups()[1].lower()
-        if unit == 'h':
-            delta = timedelta(hours=count)
-        elif unit == 'd':
-            delta = timedelta(days=count)
-        else:  # 'w'
-            delta = timedelta(weeks=count)
-        return datetime.utcnow() - delta
-    elif spec.startswith('@'):
-        try:
-            return datetime.utcfromtimestamp(int(spec[1:]))
-        except ValueError:
-            return None
-    else:
-        for fmt in ['%Y-%m-%dT%H:%M:%S.%f', '%Y-%m-%d %H:%M:%S.%f',
-                    '%Y-%m-%dT%H:%M:%S', '%Y-%m-%d %H:%M:%S', '%Y-%m-%d']:
-            try:
-                return datetime.strptime(spec, fmt)
-            except ValueError:
-                pass


### PR DESCRIPTION
The datetime parsing is done by the server; on the CLI side we now
only parse the things that aren't a datetime, ie. the special formats