### PR TITLE
pin pynacl to 1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'setuptools<=40.7.3',
         'cryptography==3.3.2',
         'cffi>=1.14,<1.15',
+        'pynacl==1.4.0',
         # Fabric depend on paramiko that depends on cryptography so we need
         # to install the correct version of cryptography before installing
         # the fabric so that fabric can be installed correctly in both py2 +


### PR DESCRIPTION
pin pynacl as 1.5.0 doesn't support py2.7 and it's collected from paramiko which is collected from fabric