### PR TITLE
Pin pynacl to 1.4.0 - 6.0.1 backport

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'setuptools<=40.7.3',
         'cryptography==3.3.2',
         'cffi>=1.14,<1.15',
+        'pynacl==1.4.0',
         # Fabric depend on paramiko that depends on cryptography so we need
         # to install the correct version of cryptography before installing
         # the fabric so that fabric can be installed correctly in both py2 +


### PR DESCRIPTION
pin-pynacl==1.4.0 as 1.5.0 is python 3.6+