### PR TITLE
RD-3239 Allow setting tenant when changing ownership

### DIFF
--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -532,11 +532,13 @@ def set_icon(blueprint_id, icon_path, logger, client):
                     short_help="Change blueprint's ownership")
 @cfy.argument('blueprint-id')
 @cfy.options.new_username()
+@cfy.options.tenant_name(required=False, resource_name_for_help='secret')
 @cfy.assert_manager_active()
-@cfy.pass_client()
+@cfy.pass_client(use_tenant_in_header=True)
 @cfy.pass_logger
-def set_owner(blueprint_id, username, logger, client):
+def set_owner(blueprint_id, username, tenant_name, logger, client):
     """Set a new owner for the blueprint."""
+    utils.explicit_tenant_name_message(tenant_name, logger)
     bp = client.blueprints.update(blueprint_id, {'creator': username})
     logger.info('Blueprint `%s` is now owned by user `%s`.',
                 blueprint_id, bp.get('created_by'))

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -852,11 +852,13 @@ def manager_set_site(deployment_id, site_name, detach_site, client, logger):
                      short_help="Change deployment's ownership")
 @cfy.argument('deployment-id')
 @cfy.options.new_username()
+@cfy.options.tenant_name(required=False, resource_name_for_help='secret')
 @cfy.assert_manager_active()
-@cfy.pass_client()
+@cfy.pass_client(use_tenant_in_header=True)
 @cfy.pass_logger
-def set_owner(deployment_id, username, logger, client):
+def set_owner(deployment_id, username, tenant_name, logger, client):
     """Set a new owner for the deployment."""
+    utils.explicit_tenant_name_message(tenant_name, logger)
     dep = client.deployments.set_attributes(deployment_id, creator=username)
     logger.info('Deployment `%s` is now owned by user `%s`.',
                 deployment_id, dep.get('created_by'))

--- a/cloudify_cli/commands/secrets.py
+++ b/cloudify_cli/commands/secrets.py
@@ -327,11 +327,13 @@ def set_visibility(key, visibility, tenant_name, logger, client):
                  short_help="Change secret's ownership")
 @cfy.argument('key', callback=cfy.validate_name)
 @cfy.options.new_username()
+@cfy.options.tenant_name(required=False, resource_name_for_help='secret')
 @cfy.assert_manager_active()
-@cfy.pass_client()
+@cfy.pass_client(use_tenant_in_header=True)
 @cfy.pass_logger
-def set_owner(key, username, logger, client):
+def set_owner(key, username, tenant_name, logger, client):
     """Set a new owner for the secret."""
+    utils.explicit_tenant_name_message(tenant_name, logger)
     secret = client.secrets.update(key, creator=username)
     logger.info('Secret `%s` is now owned by user `%s`.',
                 key, secret.get('created_by'))


### PR DESCRIPTION
Otherwise we cound not reach other tenant's objects (blueprints,
deployments, secrets).