### PR TITLE
RD-3985 cfy blueprints get labels fix

### DIFF
--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -39,7 +39,7 @@ from ..utils import prettify_client_error, get_visibility, validate_visibility
 from ..labels_utils import (add_labels,
                             delete_labels,
                             list_labels,
-                            modify_resource_labels)
+                            serialize_resource_labels)
 from .. import filters_utils
 from .summary import BASE_SUMMARY_FIELDS, structure_summary_results
 
@@ -271,7 +271,7 @@ def manager_list(filter_id,
         filter_id=filter_id
     )
     blueprints = [trim_description(b) for b in blueprints_list]
-    modify_resource_labels(blueprints)
+    serialize_resource_labels(blueprints)
     print_data(BLUEPRINT_COLUMNS, blueprints, 'Blueprints:')
 
     total = blueprints_list.metadata.pagination.total
@@ -322,7 +322,7 @@ def get(blueprint_id, logger, client, tenant_name):
         blueprint_dict['deployments'] = blueprint_deployments
         print_single(columns, blueprint_dict, 'Blueprint:', max_width=50)
     else:
-        modify_resource_labels([blueprint_dict])
+        serialize_resource_labels([blueprint_dict])
         print_single(columns, blueprint_dict, 'Blueprint:', max_width=50)
 
         logger.info('Description:')

--- a/cloudify_cli/commands/blueprints.py
+++ b/cloudify_cli/commands/blueprints.py
@@ -315,6 +315,7 @@ def get(blueprint_id, logger, client, tenant_name):
         blueprint_dict['deployments'] = blueprint_deployments
         print_single(columns, blueprint_dict, 'Blueprint:', max_width=50)
     else:
+        modify_resource_labels([blueprint_dict])
         print_single(columns, blueprint_dict, 'Blueprint:', max_width=50)
 
         logger.info('Description:')

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -61,7 +61,7 @@ from ..labels_utils import (add_labels,
                             get_output_resource_labels,
                             get_printable_resource_labels,
                             list_labels,
-                            modify_resource_labels)
+                            serialize_resource_labels)
 
 from .. import filters_utils
 from .summary import BASE_SUMMARY_FIELDS, structure_summary_results
@@ -258,7 +258,7 @@ def manager_list(blueprint_id,
                                           blueprint_id=blueprint_id,
                                           _search_name=search_name,
                                           _dependencies_of=dependencies_of)
-    modify_resource_labels(deployments)
+    serialize_resource_labels(deployments)
     total = deployments.metadata.pagination.total
     if get_global_extended_view() or get_global_json_output():
         columns = EXTENDED_DEPLOYMENT_COLUMNS

--- a/cloudify_cli/labels_utils.py
+++ b/cloudify_cli/labels_utils.py
@@ -5,7 +5,7 @@ from .utils import explicit_tenant_name_message
 from .logger import CloudifyJSONEncoder, get_global_json_output, output
 
 
-def modify_resource_labels(resource_list):
+def serialize_resource_labels(resource_list):
     for element in resource_list:
         resource_labels_list = []
         raw_labels_list = element.get('labels')


### PR DESCRIPTION
`cfy blueprints get` failed for blueprints which had some labels defined.  This patch fixes that.

And also let's display information about plugins this blueprint has in its plan (because it's easy and can be helpful).