### PR TITLE
pin jinja2 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'click>7,<8',
         'wagon[venv]>=0.10.1',
         'pyyaml==5.4.1',
-        'jinja2>=2.10,<2.11',
+        'jinja2==2.13',
         'retrying==1.3.3',
         'colorama==0.4.4',
         'requests>=2.7.0,<3.0.0',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'click>7,<8',
         'wagon[venv]>=0.10.1',
-        'pyyaml==5.4.1',
+        'pyyaml==6.0.0',
         'jinja2==2.11.3',
         'retrying==1.3.3',
         'colorama==0.4.4',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'click>7,<8',
         'wagon[venv]>=0.10.1',
         'pyyaml==5.4.1',
-        'jinja2==2.13',
+        'jinja2==2.11.3',
         'retrying==1.3.3',
         'colorama==0.4.4',
         'requests>=2.7.0,<3.0.0',


### PR DESCRIPTION
pin jinja2 to 2.11.3 according to a security vulnerability in <2.11.3 & cloudify-common 
Also pin pyyaml to 6.0.0 like in cloudify-common