### PR TITLE
Allow providing --concurrency for `cfy dep group update-deployments`

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1789,6 +1789,13 @@ class Options(object):
             help=helptexts.DEPENDENCIES_OF
         )
 
+        self.execution_group_concurrency = click.option(
+            '--concurrency',
+            type=int,
+            default=5,
+            help=helptexts.EXECUTION_GROUP_CONCURRENCY
+        )
+
     def common_options(self, f):
         """A shorthand for applying commonly used arguments.
 

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -549,6 +549,7 @@ DEP_GROUP_INTO_ENVIRONMENTS = 'Add created deployments to the environments ' \
                               'already existing in this group.'
 GROUP_ID_FILTER = 'Show only results belonging to this group'
 DELETE_GROUP_DEPLOYMENTS = 'Delete all deployments belonging to this group'
+EXECUTION_GROUP_CONCURRENCY = 'Run this many executions at a time'
 
 GENERATE_ID = 'Generate a UUID to serve as the deployment ID. This flag ' \
               'cannot be provided if a deployment ID is specified'

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -1274,12 +1274,13 @@ def delete_group_labels(label, deployment_group_name,
 @cfy.options.runtime_only_evaluation
 @cfy.options.auto_correct_types
 @cfy.options.reevaluate_active_statuses()
+@cfy.options.execution_group_concurrency
 @cfy.assert_manager_active()
 @cfy.pass_client()
 @cfy.pass_logger
 @cfy.pass_context
 def groups_update_deployments(ctx, group_id, logger, client, tenant_name,
-                              **kwargs):
+                              concurrency, **kwargs):
     """Update all deployments in the given group.
 
     If updating with a new blueprint, the blueprint must already be
@@ -1300,6 +1301,7 @@ def groups_update_deployments(ctx, group_id, logger, client, tenant_name,
         deployment_group_id=group_id,
         workflow_id='csys_update_deployment',
         default_parameters=kwargs,
+        concurrency=concurrency,
     )
     logger.info('For update status, follow this execution group: %s',
                 execution_group.id)

--- a/cloudify_cli/commands/executions.py
+++ b/cloudify_cli/commands/executions.py
@@ -560,8 +560,7 @@ def execution_groups_details(execution_group_id, client, logger):
                 short_help='Execute a workflow on each deployment in a group')
 @click.option('--deployment-group', '-g',
               help='The deployment group ID to run the workflow on')
-@click.option('--concurrency', help='Run this many executions at a time',
-              type=int, default=5)
+@cfy.options.execution_group_concurrency
 @click.argument('workflow-id')
 @cfy.options.common_options
 @cfy.options.parameters


### PR DESCRIPTION
So that we can update many deployments at a time.

Also factor out the flag, now that it's used in >1 places