### PR TITLE
RD-4380 Fix uninformative errors in cfy profile set & show-current

### DIFF
--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -784,6 +784,10 @@ def _get_client_and_assert_manager(profile_name,
     # or a password, and was expecting them to be taken from the old profile
     env.profile = env.get_profile_context(profile_name, suppress_error=True)
 
+    if not manager_ip and not env.profile.manager_ip:
+        raise CloudifyCliError('No profile defined for Cloudify CLI '
+                               'usage.\nPlease define a profile using '
+                               '`cfy profiles use`')
     client = env.get_rest_client(
         rest_host=manager_ip,
         rest_port=rest_port,

--- a/cloudify_cli/env.py
+++ b/cloudify_cli/env.py
@@ -187,7 +187,8 @@ def get_profile_context(profile_name=None, suppress_error=False):
     if not loaded:
         if suppress_error:
             return ProfileContext({})
-        raise CloudifyCliError('No context for profile {0}'
+        raise CloudifyCliError('No context for profile {0}.\nPlease define '
+                               'the profile using `cfy profiles use`'
                                .format(profile_name))
     return ProfileContext(loaded, profile_name)
 


### PR DESCRIPTION
If running `cfy profiles set` before `cfy profiles use`, then both `show-current` and the `set` command itself give uninformative errors (set before use gives `inet_pton() argument 2 must be str, not None` which is horrible). This PR fixes it