### PR TITLE
Don't check auth before setting profile settings 

### DIFF
--- a/cloudify_cli/commands/profiles.py
+++ b/cloudify_cli/commands/profiles.py
@@ -373,13 +373,6 @@ def set_cmd(profile_name,
             "You must supply at least one of the following:  "
             "profile name, username, password, token, tenant, "
             "ssl, rest certificate, ssh user, ssh key, ssh port, kerberos env")
-    if not skip_credentials_validation:
-        env.check_configured_auth(
-            credentials=(manager_username, manager_password),
-            token=manager_token,
-            kerberos_env=kerberos_env,
-        )
-
     old_name = None
     if profile_name:
         if profile_name == 'local':


### PR DESCRIPTION
We check before saving anyway, and checking before processing
the new settings will run into interesting issues (e.g. when
trying to set a token while username and password are already set).