### PR TITLE
RD-4616 Hide unavailable workflows

### DIFF
--- a/cloudify_cli/commands/workflows.py
+++ b/cloudify_cli/commands/workflows.py
@@ -23,7 +23,7 @@ from .. import utils
 from ..cli import cfy
 from ..exceptions import CloudifyCliError
 
-WORKFLOW_COLUMNS = ['blueprint_id', 'deployment_id', 'name', 'created_at']
+WORKFLOW_COLUMNS = ['blueprint_id', 'deployment_id', 'name',]
 
 
 @cfy.group(name='workflows')

--- a/cloudify_cli/commands/workflows.py
+++ b/cloudify_cli/commands/workflows.py
@@ -23,7 +23,7 @@ from .. import utils
 from ..cli import cfy
 from ..exceptions import CloudifyCliError
 
-WORKFLOW_COLUMNS = ['blueprint_id', 'deployment_id', 'name',]
+WORKFLOW_COLUMNS = ['blueprint_id', 'deployment_id', 'name']
 
 
 @cfy.group(name='workflows')
@@ -108,7 +108,8 @@ def get(workflow_id, deployment_id, logger, client, tenant_name):
                    short_help='List workflows for a deployment [manager only]')
 @cfy.options.deployment_id(required=True)
 @cfy.options.common_options
-@click.option('--all', 'all_workflows', is_flag=True, help='Also show unavailable workflows')
+@click.option('--all', 'all_workflows', is_flag=True,
+              help='Also show unavailable workflows')
 @cfy.options.tenant_name(required=False, resource_name_for_help='deployment')
 @cfy.pass_logger
 @cfy.pass_client()

--- a/cloudify_cli/commands/workflows.py
+++ b/cloudify_cli/commands/workflows.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 ############
 
+import click
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 from ..logger import get_global_json_output
@@ -107,21 +108,34 @@ def get(workflow_id, deployment_id, logger, client, tenant_name):
                    short_help='List workflows for a deployment [manager only]')
 @cfy.options.deployment_id(required=True)
 @cfy.options.common_options
+@click.option('--all', 'all_workflows', is_flag=True, help='Also show unavailable workflows')
 @cfy.options.tenant_name(required=False, resource_name_for_help='deployment')
 @cfy.pass_logger
 @cfy.pass_client()
 @cfy.options.extended_view
-def list(deployment_id, logger, client, tenant_name):
+def list(deployment_id, all_workflows, logger, client, tenant_name):
     """List all workflows on the manager for a specific deployment
     """
     utils.explicit_tenant_name_message(tenant_name, logger)
-    logger.info('Listing workflows for deployment {0}...'.format(
-        deployment_id))
+    logger.info('Listing workflows for deployment %s...', deployment_id)
     deployment = client.deployments.get(deployment_id)
+
     workflows = sorted(deployment.workflows, key=lambda w: w.name)
+
+    columns = WORKFLOW_COLUMNS
+    hidden_count = 0
+    if not all_workflows:
+        total_count = len(workflows)
+        workflows = [wf for wf in workflows if wf.is_available]
+        hidden_count = total_count - len(workflows)
+    else:
+        columns = columns + ['is_available']
 
     defaults = {
         'blueprint_id': deployment.blueprint_id,
         'deployment_id': deployment.id
     }
-    print_data(WORKFLOW_COLUMNS, workflows, 'Workflows:', defaults=defaults)
+    print_data(columns, workflows, 'Workflows:', defaults=defaults)
+    if hidden_count:
+        logger.info('%d unavailable workflows hidden (use --all to show)',
+                    hidden_count)

--- a/cloudify_cli/tests/commands/test_workflows.py
+++ b/cloudify_cli/tests/commands/test_workflows.py
@@ -16,7 +16,7 @@
 
 import json
 
-from mock import MagicMock
+from mock import Mock
 
 from cloudify_cli.logger import set_global_json_output
 
@@ -53,7 +53,7 @@ class WorkflowsTest(CliCommandTest):
             ]
         })
 
-        self.client.deployments.get = MagicMock(return_value=deployment)
+        self.client.deployments.get = Mock(return_value=deployment)
         self.invoke('cfy workflows list -d a-deployment-id')
 
     def test_workflows_sort_list(self):
@@ -94,7 +94,7 @@ class WorkflowsTest(CliCommandTest):
             ]
         })
 
-        self.client.deployments.get = MagicMock(return_value=deployment)
+        self.client.deployments.get = Mock(return_value=deployment)
 
         output = self.invoke('cfy workflows list -d a-deployment-id').output
         first = output.find('my_workflow_0')
@@ -123,7 +123,7 @@ class WorkflowsTest(CliCommandTest):
             ]
         })
 
-        self.client.deployments.get = MagicMock(return_value=deployment)
+        self.client.deployments.get = Mock(return_value=deployment)
         outcome = self.invoke('workflows get mock_workflow -d dep_id')
         self.assertIn('test-mandatory-key', outcome.output)
         self.assertIn('nested value', outcome.output)
@@ -150,7 +150,7 @@ class WorkflowsTest(CliCommandTest):
             ]
         })
 
-        self.client.deployments.get = MagicMock(return_value=deployment)
+        self.client.deployments.get = Mock(return_value=deployment)
         outcome = self.invoke('workflows get mock_workflow -d dep_id --json')
         parsed = json.loads(outcome.output)
         self.assertEqual(deployment.workflows[0]['parameters'],
@@ -181,7 +181,7 @@ class WorkflowsTest(CliCommandTest):
             ]
         })
 
-        self.client.deployments.get = MagicMock(return_value=deployment)
+        self.client.deployments.get = Mock(return_value=deployment)
         self.invoke('cfy workflows get nonexistent_workflow -d dep_id',
                     expected_message)
 
@@ -190,7 +190,7 @@ class WorkflowsTest(CliCommandTest):
         expected_message = \
             "Deployment 'nonexistent-dep' not found on manager server"
 
-        self.client.deployments.get = MagicMock(
+        self.client.deployments.get = Mock(
             side_effect=CloudifyClientError(expected_message))
         self.invoke('cfy workflows get wf -d nonexistent-dep -v',
                     err_str_segment=expected_message,
@@ -209,7 +209,7 @@ class WorkflowsTest(CliCommandTest):
                 }
             ]
         })
-        self.client.deployments.get = MagicMock(return_value=deployment)
+        self.client.deployments.get = Mock(return_value=deployment)
 
         # listing by default only shows available wfs
         outcome = self.invoke('workflows list -d d1 --json')


### PR DESCRIPTION
When listing workflows, only show available ones by default, based
on the restservice response.

There's also a flag to show all of them