### PR TITLE
RD-4990 Add `cfy nodes list --run-checks`

### DIFF
--- a/cloudify_cli/commands/nodes.py
+++ b/cloudify_cli/commands/nodes.py
@@ -142,7 +142,7 @@ def _run_node_checks(deployment_id, logger, client):
 @nodes.command(name='list',
                short_help='List nodes for a deployment '
                '[manager only]')
-@cfy.options.deployment_id(required=True)
+@cfy.options.deployment_id()
 @cfy.options.sort_by('deployment_id')
 @cfy.options.descending
 @cfy.options.tenant_name_for_list(
@@ -180,12 +180,17 @@ def nodes_list(
     """
     utils.explicit_tenant_name_message(tenant_name, logger)
     if run_checks:
+        if not deployment_id:
+            raise CloudifyCliError(
+                "deployment_id is required when --run-checks is set")
         _run_node_checks(deployment_id, logger, client)
     try:
         if deployment_id:
             logger.info('Listing nodes for deployment %s...', deployment_id)
+            instance_counts = True
         else:
             logger.info('Listing all nodes...')
+            instance_counts = False
         nodes = client.nodes.list(
             deployment_id=deployment_id,
             sort=sort_by,
@@ -194,7 +199,7 @@ def nodes_list(
             _search=search,
             _offset=pagination_offset,
             _size=pagination_size,
-            _instance_counts=True,
+            _instance_counts=instance_counts,
         )
     except CloudifyClientError as e:
         if e.status_code != 404:

--- a/cloudify_cli/logger.py
+++ b/cloudify_cli/logger.py
@@ -159,7 +159,7 @@ def _configure_from_file(loggers_config):
         }
 
 
-def get_events_logger(json_output, with_names=False):
+def get_events_logger(json_output=False, with_names=False):
     json_output = json_output or get_global_json_output()
 
     def json_events_logger(events):


### PR DESCRIPTION
Add a shorthand to automatically run check_drift & check_staus
before showing the nodes list.

Also, I'm making json_output default to false to that logger
function. `--json-output` is deprecated anyway (replaced by just
the regular --json/--format=json)