### PR TITLE
nodes list: only show instance counts when dep_id is passed

### DIFF
--- a/cloudify_cli/commands/nodes.py
+++ b/cloudify_cli/commands/nodes.py
@@ -208,7 +208,10 @@ def nodes_list(
             deployment_id))
 
     columns = list(NODE_COLUMNS)
-    if get_global_json_output() or get_global_extended_view():
+    if (
+        (get_global_json_output() or get_global_extended_view())
+        and deployment_id
+    ):
         columns = columns + ['drifted_instances', 'unavailable_instances']
     print_data(columns, nodes, 'Nodes:', labels=NODE_TABLE_LABELS)
     total = nodes.metadata.pagination.total


### PR DESCRIPTION
Without deployment_id, the counts are always 0. No need to show
that, it's just misleading.

Maybe we should just deprecate or remove listing all nodes ever
(without a dep-id), it's not very useful.