### PR TITLE
Reorder common options

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1831,8 +1831,8 @@ class Options(object):
         To be used for arguments that are going to be applied for all or
         almost all commands.
         """
-        for arg in [self.json, self.verbose(), self.format, self.quiet(),
-                    self.manager]:
+        for arg in [self.manager, self.json, self.format,
+                    self.verbose(), self.quiet()]:
             f = arg(f)
         return f
 


### PR DESCRIPTION
The ordering here affects the ordering of the display in --help,
and I think this way makes more sense: verbose next to quiet, json
next to format.