### PR TITLE
RD-5128 Fix `--all-tenants` functionality in plugins update

### DIFF
--- a/cloudify_cli/commands/plugins.py
+++ b/cloudify_cli/commands/plugins.py
@@ -562,20 +562,22 @@ def update(blueprint_id,
             'only the specific plugins, use --plugin-name parameter instead.')
 
     if blueprint_id:
-        _update_a_blueprint(blueprint_id,
-                            plugin_names,
-                            to_latest,
-                            all_to_latest,
-                            to_minor,
-                            all_to_minor,
-                            include_logs,
-                            json_output,
-                            logger,
-                            force,
-                            auto_correct_types,
-                            reevaluate_active_statuses,
-                            client,
-                            tenant_name)
+        _update_a_blueprint(
+            blueprint_id,
+            plugin_names,
+            to_latest,
+            all_to_latest,
+            to_minor,
+            all_to_minor,
+            include_logs,
+            json_output,
+            logger,
+            force,
+            auto_correct_types,
+            reevaluate_active_statuses,
+            client,
+            tenant_name,
+        )
     elif all_blueprints:
         update_results = {'successful': [], 'failed': []}
         pagination_offset = 0

--- a/cloudify_cli/commands/plugins.py
+++ b/cloudify_cli/commands/plugins.py
@@ -591,7 +591,7 @@ def update(blueprint_id,
                 if blueprint.id in except_blueprints:
                     continue
                 try:
-                    _update_a_blueprint(blueprint.get('id'),
+                    _update_a_blueprint(blueprint.id,
                                         plugin_names,
                                         to_latest,
                                         all_to_latest,
@@ -604,7 +604,7 @@ def update(blueprint_id,
                                         auto_correct_types,
                                         reevaluate_active_statuses,
                                         client,
-                                        blueprint.get('tenant_name'))
+                                        blueprint.tenant_name)
                     update_results['successful'].append(blueprint.id)
                 except (CloudifyClientError, SuppressedCloudifyCliError) as ex:
                     update_results['failed'].append(blueprint.id)

--- a/cloudify_cli/commands/plugins.py
+++ b/cloudify_cli/commands/plugins.py
@@ -29,6 +29,7 @@ from cloudify_cli.exceptions import (
     SuppressedCloudifyCliError, CloudifyCliError, CloudifyValidationError,
 )
 
+from cloudify_rest_client.client import CLOUDIFY_TENANT_HEADER
 from cloudify_rest_client.constants import VISIBILITY_EXCEPT_PRIVATE
 from cloudify_rest_client.exceptions import CloudifyClientError
 
@@ -560,19 +561,27 @@ def update(blueprint_id,
             '--to-minor are mutually exclusive.  If you want to upgrade '
             'only the specific plugins, use --plugin-name parameter instead.')
 
-    utils.explicit_tenant_name_message(tenant_name, logger)
     if blueprint_id:
-        _update_a_blueprint(blueprint_id, all_tenants, plugin_names,
-                            to_latest, all_to_latest, to_minor, all_to_minor,
-                            include_logs, json_output, logger,
-                            client, force, auto_correct_types,
-                            reevaluate_active_statuses)
+        _update_a_blueprint(blueprint_id,
+                            plugin_names,
+                            to_latest,
+                            all_to_latest,
+                            to_minor,
+                            all_to_minor,
+                            include_logs,
+                            json_output,
+                            logger,
+                            force,
+                            auto_correct_types,
+                            reevaluate_active_statuses,
+                            client,
+                            tenant_name)
     elif all_blueprints:
         update_results = {'successful': [], 'failed': []}
         pagination_offset = 0
         while True:
             blueprints = client.blueprints.list(
-                sort='created_at',
+                sort=['tenant_name', 'created_at'],
                 _all_tenants=all_tenants,
                 _offset=pagination_offset,
             )
@@ -580,12 +589,20 @@ def update(blueprint_id,
                 if blueprint.id in except_blueprints:
                     continue
                 try:
-                    _update_a_blueprint(blueprint.id, all_tenants,
-                                        plugin_names, to_latest, all_to_latest,
-                                        to_minor, all_to_minor,
-                                        include_logs, json_output, logger,
-                                        client, force, auto_correct_types,
-                                        reevaluate_active_statuses)
+                    _update_a_blueprint(blueprint.get('id'),
+                                        plugin_names,
+                                        to_latest,
+                                        all_to_latest,
+                                        to_minor,
+                                        all_to_minor,
+                                        include_logs,
+                                        json_output,
+                                        logger,
+                                        force,
+                                        auto_correct_types,
+                                        reevaluate_active_statuses,
+                                        client,
+                                        blueprint.get('tenant_name'))
                     update_results['successful'].append(blueprint.id)
                 except (CloudifyClientError, SuppressedCloudifyCliError) as ex:
                     update_results['failed'].append(blueprint.id)
@@ -645,7 +662,6 @@ def updates_list(tenant_name,
 
 
 def _update_a_blueprint(blueprint_id,
-                        all_tenants,
                         plugin_names,
                         to_latest,
                         all_to_latest,
@@ -654,10 +670,13 @@ def _update_a_blueprint(blueprint_id,
                         include_logs,
                         json_output,
                         logger,
-                        client,
                         force,
                         auto_correct_types,
-                        reevaluate_active_statuses):
+                        reevaluate_active_statuses,
+                        client,
+                        tenant_name):
+    utils.explicit_tenant_name_message(tenant_name, logger)
+    client._client._set_header(CLOUDIFY_TENANT_HEADER, tenant_name)
     logger.info('Updating the plugins of the deployments of the blueprint %s',
                 blueprint_id)
     plugins_update = client.plugins_update.update_plugins(
@@ -666,7 +685,6 @@ def _update_a_blueprint(blueprint_id,
         to_minor=to_minor, all_to_minor=all_to_minor,
         auto_correct_types=auto_correct_types,
         reevaluate_active_statuses=reevaluate_active_statuses,
-        all_tenants=all_tenants,
     )
     events_logger = get_events_logger(json_output)
     execution = execution_events_fetcher.wait_for_execution(

--- a/cloudify_cli/tests/commands/test_plugins.py
+++ b/cloudify_cli/tests/commands/test_plugins.py
@@ -445,11 +445,12 @@ class PluginsUpdateTest(CliCommandTest):
                           'cfy plugins update asdf --all-blueprints')
 
     def test_all(self):
-        bp = namedtuple('Blueprint', 'id')
+        bp = namedtuple('Blueprint', ('id', 'tenant_name'))
         update_client_mock = Mock()
         bp_list_client_mock = Mock(
             return_value=MockListResponseWithPaginationSize(
-                items=[bp(id='asdf'), bp(id='zxcv')]))
+                items=[bp(id='asdf', tenant_name='default_tenant'),
+                       bp(id='zxcv', tenant_name='default_tenant')]))
         self.client.plugins_update.update_plugins = update_client_mock
         self.client.blueprints.list = bp_list_client_mock
         self.invoke('cfy plugins update --all-blueprints')
@@ -458,13 +459,11 @@ class PluginsUpdateTest(CliCommandTest):
         self.assertListEqual(
             list(update_client_mock.call_args_list),
             [call('asdf', force=False, plugin_names=[],
-                  all_tenants=False,
                   to_latest=[], all_to_latest=True,
                   to_minor=[], all_to_minor=False,
                   auto_correct_types=False,
                   reevaluate_active_statuses=False),
              call('zxcv', force=False, plugin_names=[],
-                  all_tenants=False,
                   to_latest=[], all_to_latest=True,
                   to_minor=[], all_to_minor=False,
                   auto_correct_types=False,
@@ -483,11 +482,13 @@ class PluginsUpdateTest(CliCommandTest):
                           'cfy plugins update --except-blueprint asdf')
 
     def test_except_blueprints(self):
-        bp = namedtuple('Blueprint', 'id')
+        bp = namedtuple('Blueprint', ('id', 'tenant_name'))
         update_client_mock = Mock()
         bp_list_client_mock = Mock(
             return_value=MockListResponseWithPaginationSize(
-                items=[bp(id='asdf'), bp(id='zxcv'), bp(id='1234')]))
+                items=[bp(id='asdf', tenant_name='default_tenant'),
+                       bp(id='zxcv', tenant_name='default_tenant'),
+                       bp(id='1234', tenant_name='default_tenant')]))
         self.client.plugins_update.update_plugins = update_client_mock
         self.client.blueprints.list = bp_list_client_mock
         self.invoke('cfy plugins update --all-blueprints '
@@ -496,7 +497,7 @@ class PluginsUpdateTest(CliCommandTest):
         self.assertEqual(len(update_client_mock.mock_calls), 1)
         self.assertListEqual(
             list(update_client_mock.call_args_list),
-            [call('zxcv', force=False, plugin_names=[], all_tenants=False,
+            [call('zxcv', force=False, plugin_names=[],
                   to_latest=[], all_to_latest=True,
                   to_minor=[], all_to_minor=False,
                   auto_correct_types=False,


### PR DESCRIPTION
Just call the operation in the blueprint tenant's context