### PR TITLE
RD-5234 Use JSON to read dict instead of glob

### DIFF
--- a/cloudify_cli/inputs.py
+++ b/cloudify_cli/inputs.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 import os
 import glob
 import yaml
+import json
 
 from cloudify._compat import text_type
 
@@ -135,6 +136,13 @@ def _is_not_plain_string_input(mapped_input):
 
 
 def plain_string_to_dict(input_string, **kwargs):
+    try:
+        input_dict = json.loads(input_string)
+        if isinstance(input_dict, dict):
+            return input_dict
+    except ValueError:
+        pass
+
     input_string = input_string.strip()
     input_dict = {}
     mapped_inputs = input_string.split(';')

--- a/cloudify_cli/tests/commands/test_node_instances.py
+++ b/cloudify_cli/tests/commands/test_node_instances.py
@@ -96,6 +96,18 @@ class NodeInstancesTest(CliCommandTest):
         self.invoke('cfy node-instances update-runtime instance_id -p x.y=z')
         self.assertEqual('z', call_args[1]['runtime_properties']['x']['y'])
 
+    def test_update_runtime_successful_json_format(self):
+        self.client.node_instances.get = \
+            MagicMock(return_value=node_instance_get_mock())
+        self.client.node_instances.update = MagicMock(return_value={})
+
+        self.invoke('cfy node-instances update-runtime instance_id '
+                    '-p \'{"a":[],"b":"m-3","c":["d","e"]}\'')
+        call_args = self.client.node_instances.update.call_args
+        self.assertEqual([], call_args[1]['runtime_properties']['a'])
+        self.assertEqual('m-3', call_args[1]['runtime_properties']['b'])
+        self.assertEqual(['d', 'e'], call_args[1]['runtime_properties']['c'])
+
     def test_update_runtime_successful_key_exists(self):
         self.client.node_instances.get = \
             MagicMock(return_value=node_instance_get_mock())


### PR DESCRIPTION
Turns out `glob` here https://github.com/cloudify-cosmo/cloudify-cli/blob/535491cc4c2e7b803537928acdbf8eadda03ea88/cloudify_cli/inputs.py#L83 acts funny when parsing dicts, trying to read things like `m-3` as character ranges. Let's avoid it completely