### PR TITLE
RD-4466 Allow empty update

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1825,6 +1825,15 @@ class Options(object):
             default=False,
         )
 
+        self.empty_update = click.option(
+            '--empty-update',
+            is_flag=True,
+            help=helptexts.EMPTY_UPDATE,
+            default=False,
+            cls=MutuallyExclusiveOption,
+            mutually_exclusive=['blueprint_id', 'blueprint_path', 'inputs'],
+        )
+
     def common_options(self, f):
         """A shorthand for applying commonly used arguments.
 

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -588,3 +588,5 @@ AUDIT_TRUNCATE_BEFORE = 'Truncate audit logs which were stored this long ' \
 SET_USERNAME = 'The name of the user who will be the new owner '\
                'of the resource.'
 WORKER_NAMES = 'Show the worker name for each event'
+EMPTY_UPDATE = 'Run update without changing anything. This will still check ' \
+               'drift and run update operations as necessary'

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -438,6 +438,7 @@ def manager_get_update(deployment_update_id, logger, client, tenant_name):
 @cfy.options.visibility(mutually_exclusive_required=False)
 @cfy.options.validate
 @cfy.options.include_logs
+@cfy.options.empty_update
 @cfy.options.json_output
 @cfy.options.common_options
 @cfy.options.runtime_only_evaluation
@@ -469,6 +470,7 @@ def manager_update(
     client,
     tenant_name,
     blueprint_id,
+    empty_update,
     visibility,
     validate,
     runtime_only_evaluation,
@@ -494,7 +496,7 @@ def manager_update(
             'supported.  Use -b, --blueprint-id option instead to pass an ID '
             'of a blueprint that is already in the system, e.g. '
             '`cfy deployments update -b UPDATED_BLUEPRINT_ID DEPLOYMENT_ID`.')
-    if not any([blueprint_id, blueprint_path, inputs]):
+    if not any([blueprint_id, blueprint_path, inputs, empty_update]):
         raise CloudifyCliError(
             'Must supply either a blueprint (by id of an existing blueprint, '
             'or a path to a new blueprint), or new inputs')


### PR DESCRIPTION
Allow an update that doesn't change the deployment itself, but will
still run

Presumably we'll have another, better, interface to run this later on,
but let's have one right now that allows actually running it at all.