### PR TITLE
RD-4466 dep-up: add the skip-drift-check flag

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -894,6 +894,11 @@ class Options(object):
             is_flag=True,
             help=helptexts.SKIP_REINSTALL)
 
+        self.skip_drift_check = click.option(
+            '--skip-drift-check',
+            is_flag=True,
+            help=helptexts.SKIP_DRIFT_CHECK)
+
         self.dont_skip_reinstall = click.option(
             '--dont-skip-reinstall',
             is_flag=True,

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -91,6 +91,7 @@ SKIP_REINSTALL = (
     "been modified, as part of a deployment update. Node instances that were "
     "explicitly given to the reinstall list will still be reinstalled"
 )
+SKIP_DRIFT_CHECK = "Skip running check_drift during deployment update"
 DONT_SKIP_REINSTALL = (
     "Reinstall node-instances that their properties have been modified as part"
     " of a deployment update. Node instances that were explicitly specified"

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -429,6 +429,7 @@ def manager_get_update(deployment_update_id, logger, client, tenant_name):
 @cfy.options.skip_install
 @cfy.options.skip_uninstall
 @cfy.options.skip_reinstall
+@cfy.options.skip_drift_check
 @cfy.options.ignore_failure
 @cfy.options.install_first
 @cfy.options.preview
@@ -458,6 +459,7 @@ def manager_update(
     skip_install,
     skip_uninstall,
     skip_reinstall,
+    skip_drift_check,
     ignore_failure,
     install_first,
     preview,
@@ -527,6 +529,7 @@ def manager_update(
             skip_install,
             skip_uninstall,
             skip_reinstall,
+            skip_drift_check,
             workflow_id,
             force,
             ignore_failure,
@@ -1339,6 +1342,7 @@ def delete_group_labels(label, deployment_group_name,
 @cfy.options.skip_install
 @cfy.options.skip_uninstall
 @cfy.options.skip_reinstall
+@cfy.options.skip_drift_check
 @cfy.options.ignore_failure
 @cfy.options.install_first
 @cfy.options.dont_update_plugins


### PR DESCRIPTION
This will just skip the drift check. Duh.

The rest-client part of this is cloudify-cosmo/cloudify-common#1108