### PR TITLE
RD-4466 dep-up: add the force-reinstall flag

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -899,6 +899,11 @@ class Options(object):
             is_flag=True,
             help=helptexts.SKIP_DRIFT_CHECK)
 
+        self.force_reinstall = click.option(
+            '--force-reinstall',
+            is_flag=True,
+            help=helptexts.FORCE_REINSTALL)
+
         self.dont_skip_reinstall = click.option(
             '--dont-skip-reinstall',
             is_flag=True,

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -92,6 +92,7 @@ SKIP_REINSTALL = (
     "explicitly given to the reinstall list will still be reinstalled"
 )
 SKIP_DRIFT_CHECK = "Skip running check_drift during deployment update"
+FORCE_REINSTALL = "Reinstall all changed nodes, don't run update operations"
 DONT_SKIP_REINSTALL = (
     "Reinstall node-instances that their properties have been modified as part"
     " of a deployment update. Node instances that were explicitly specified"

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -430,6 +430,7 @@ def manager_get_update(deployment_update_id, logger, client, tenant_name):
 @cfy.options.skip_uninstall
 @cfy.options.skip_reinstall
 @cfy.options.skip_drift_check
+@cfy.options.force_reinstall
 @cfy.options.ignore_failure
 @cfy.options.install_first
 @cfy.options.preview
@@ -460,6 +461,7 @@ def manager_update(
     skip_uninstall,
     skip_reinstall,
     skip_drift_check,
+    force_reinstall,
     ignore_failure,
     install_first,
     preview,
@@ -530,6 +532,7 @@ def manager_update(
             skip_uninstall,
             skip_reinstall,
             skip_drift_check,
+            force_reinstall,
             workflow_id,
             force,
             ignore_failure,
@@ -1343,6 +1346,7 @@ def delete_group_labels(label, deployment_group_name,
 @cfy.options.skip_uninstall
 @cfy.options.skip_reinstall
 @cfy.options.skip_drift_check
+@cfy.options.force_reinstall
 @cfy.options.ignore_failure
 @cfy.options.install_first
 @cfy.options.dont_update_plugins


### PR DESCRIPTION
This will make the changed nodes be just reinstalled, bypassing
the update interfaces