### PR TITLE
cfy dep update: rename --empty-update to --drift-only

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1853,10 +1853,10 @@ class Options(object):
             default=False,
         )
 
-        self.empty_update = click.option(
-            '--empty-update',
+        self.drift_only = click.option(
+            '--drift-only',
             is_flag=True,
-            help=helptexts.EMPTY_UPDATE,
+            help=helptexts.DRIFT_ONLY,
             default=False,
             cls=MutuallyExclusiveOption,
             mutually_exclusive=['blueprint_id', 'blueprint_path', 'inputs'],

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -591,8 +591,8 @@ AUDIT_TRUNCATE_BEFORE = 'Truncate audit logs which were stored this long ' \
 SET_USERNAME = 'The name of the user who will be the new owner '\
                'of the resource.'
 WORKER_NAMES = 'Show the worker name for each event'
-EMPTY_UPDATE = 'Run update without changing anything. This will still check ' \
-               'drift and run update operations as necessary'
+DRIFT_ONLY = 'Run update without changing anything. This will still check ' \
+             'drift and run update operations as necessary'
 TEMPDIR_PATH = "Temporary location to be used for snapshot creation. If not " \
                "specified, /tmp will be used."
 WAIT_FOR_STATUS = "Whether to wait for snapshot status [default: False]."

--- a/cloudify_cli/commands/deployments.py
+++ b/cloudify_cli/commands/deployments.py
@@ -441,7 +441,7 @@ def manager_get_update(deployment_update_id, logger, client, tenant_name):
 @cfy.options.visibility(mutually_exclusive_required=False)
 @cfy.options.validate
 @cfy.options.include_logs
-@cfy.options.empty_update
+@cfy.options.drift_only
 @cfy.options.json_output
 @cfy.options.common_options
 @cfy.options.runtime_only_evaluation
@@ -476,7 +476,7 @@ def manager_update(
     client,
     tenant_name,
     blueprint_id,
-    empty_update,
+    drift_only,
     visibility,
     validate,
     runtime_only_evaluation,
@@ -502,7 +502,7 @@ def manager_update(
             'supported.  Use -b, --blueprint-id option instead to pass an ID '
             'of a blueprint that is already in the system, e.g. '
             '`cfy deployments update -b UPDATED_BLUEPRINT_ID DEPLOYMENT_ID`.')
-    if not any([blueprint_id, blueprint_path, inputs, empty_update]):
+    if not any([blueprint_id, blueprint_path, inputs, drift_only]):
         raise CloudifyCliError(
             'Must supply either a blueprint (by id of an existing blueprint, '
             'or a path to a new blueprint), or new inputs')


### PR DESCRIPTION
This is better because:
1. Talks about what will the update do
2. Doesn't include the word "update" in the flag (it's already
   `cfy dep update`, right)

Also, product prefers this.