### PR TITLE
debian build.sh: download the up-to-date python package

### DIFF
--- a/packaging/debian/build.sh
+++ b/packaging/debian/build.sh
@@ -31,7 +31,7 @@ Description: Cloudify's Command Line Interface
 EOF
 
 # Download and untar our python3.10 package
-curl https://cloudify-cicd.s3.amazonaws.com/python-build-packages/cfy-python3.10.tgz -o cfy-python3.10.tgz
+curl https://cloudify-cicd.s3.amazonaws.com/python-build-packages/cfy-python3.10-x86_64.tgz -o cfy-python3.10.tgz
 tar xf cfy-python3.10.tgz -C /
 
 /opt/python3.10/bin/python3.10 -m venv /opt/cfy


### PR DESCRIPTION
The other one was actually `Last-Modified: Mon, 19 Sep 2022 12:26:00 GMT`

This is the proper URL now, and I'm gonna hardcode x86_64 (ie. no aarch support here), because this already hardcodes amd64 in the control file.