### PR TITLE
RD-6537 agents list: add `--all-states`

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1950,24 +1950,37 @@ class Options(object):
 
         Applies deployment id, node id and node instance id filters.
         """
-        node_instance_id = click.option('--node-instance-id', multiple=True,
-                                        help=helptexts.AGENT_NODE_INSTANCE_ID,
-                                        callback=self.parse_comma_separated)
-        node_id = click.option('--node-id', multiple=True,
-                               help=helptexts.AGENT_NODE_ID,
-                               callback=self.parse_comma_separated)
-        install_method = click.option('--install-method', multiple=True,
-                                      help=helptexts.AGENT_INSTALL_METHOD,
-                                      callback=self.parse_comma_separated)
-        deployment_id = click.option('--deployment-id', multiple=True,
-                                     help=helptexts.AGENT_DEPLOYMENT_ID,
-                                     callback=self.parse_comma_separated)
-        all_states =click.option(
+        node_instance_id = click.option(
+            '--node-instance-id',
+            multiple=True,
+            help=helptexts.AGENT_NODE_INSTANCE_ID,
+            callback=self.parse_comma_separated,
+        )
+        node_id = click.option(
+            '--node-id',
+            multiple=True,
+            help=helptexts.AGENT_NODE_ID,
+            callback=self.parse_comma_separated,
+        )
+        install_method = click.option(
+            '--install-method',
+            multiple=True,
+            help=helptexts.AGENT_INSTALL_METHOD,
+            callback=self.parse_comma_separated,
+        )
+        deployment_id = click.option(
+            '--deployment-id',
+            multiple=True,
+            help=helptexts.AGENT_DEPLOYMENT_ID,
+            callback=self.parse_comma_separated,
+        )
+        all_states = click.option(
             '--all-states',
             default=False,
             is_flag=True,
             help=helptexts.AGENT_ALL_STATES,
         )
+
         # we add separate --node-instance-id, --node-id and --deployment-id
         # arguments, but only expose a agents_filter = {'node_id': ..} dict
         # to the decorated function

--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -16,6 +16,7 @@ from urllib.parse import quote as urlquote
 
 import click
 
+from cloudify.models_states import AgentState
 from cloudify_rest_client.constants import VisibilityState
 from cloudify_rest_client.exceptions import NotModifiedError
 from cloudify_rest_client.exceptions import CloudifyClientError
@@ -1961,7 +1962,12 @@ class Options(object):
         deployment_id = click.option('--deployment-id', multiple=True,
                                      help=helptexts.AGENT_DEPLOYMENT_ID,
                                      callback=self.parse_comma_separated)
-
+        all_states =click.option(
+            '--all-states',
+            default=False,
+            is_flag=True,
+            help=helptexts.AGENT_ALL_STATES,
+        )
         # we add separate --node-instance-id, --node-id and --deployment-id
         # arguments, but only expose a agents_filter = {'node_id': ..} dict
         # to the decorated function
@@ -1976,12 +1982,14 @@ class Options(object):
                         ('install_method', AGENT_FILTER_INSTALL_METHODS)]:
                     filters[filter_name] = kwargs.pop(arg_name, None)
 
+                if not kwargs.pop('all_states', False):
+                    filters['state'] = [AgentState.STARTED]
                 kwargs['agent_filters'] = filters
                 return f(*args, **kwargs)
             return _inner
 
         for arg in [install_method, node_instance_id, node_id,
-                    deployment_id, _filters_deco]:
+                    deployment_id, all_states, _filters_deco]:
             f = arg(f)
         return f
 

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -433,6 +433,7 @@ AGENT_NODE_ID = 'The node id to be used for filtering' \
 AGENT_INSTALL_METHOD = 'Only show agents installed with this install_method' \
                        + _MULTIPLE_TIMES_FRAGMENT
 AGENT_DEPLOYMENT_ID = DEPLOYMENT_ID + _MULTIPLE_TIMES_FRAGMENT
+AGENT_ALL_STATES = 'Show agents in all states, not only started ones'
 
 AGENTS_WAIT = "Wait for agents operations to end, and show execution logs"
 INSTALL_AGENT_TIMEOUT = "Agent installation timeout"

--- a/cloudify_cli/commands/agents.py
+++ b/cloudify_cli/commands/agents.py
@@ -35,8 +35,8 @@ from cloudify_cli.table import print_data
 
 
 _NODE_INSTANCE_STATE_STARTED = 'started'
-AGENT_COLUMNS = ['id', 'ip', 'deployment', 'node', 'system', 'version',
-                 'install_method', 'tenant_name']
+AGENT_COLUMNS = ['id', 'ip', 'deployment', 'state', 'node', 'system',
+                 'version', 'install_method', 'tenant_name']
 
 MAX_TRACKER_THREADS = 20
 

--- a/cloudify_cli/tests/commands/test_options.py
+++ b/cloudify_cli/tests/commands/test_options.py
@@ -1,5 +1,6 @@
 from mock import MagicMock
 
+from cloudify.models_states import AgentState
 from cloudify_cli.logger import get_global_json_output
 
 from .mocks import MockListResponse
@@ -33,7 +34,9 @@ class OptionsTest(CliCommandTest):
             install_methods=[],
             node_ids=['a'],
             node_instance_ids=[],
-            _all_tenants=True)
+            _all_tenants=True,
+            state=[AgentState.STARTED],
+        )
 
     def test_agent_filters_multiple(self):
         self.invoke('agents list --node-id a --node-id b')
@@ -42,7 +45,9 @@ class OptionsTest(CliCommandTest):
             install_methods=[],
             node_ids=['a', 'b'],
             node_instance_ids=[],
-            _all_tenants=False)
+            _all_tenants=False,
+            state=[AgentState.STARTED],
+        )
 
     def test_agent_filters_commaseparated(self):
         self.invoke('agents list --node-id a,b')
@@ -51,7 +56,9 @@ class OptionsTest(CliCommandTest):
             install_methods=[],
             node_ids=['a', 'b'],
             node_instance_ids=[],
-            _all_tenants=False)
+            _all_tenants=False,
+            state=[AgentState.STARTED],
+        )
 
     def test_agent_filters_commaseparated_multiple(self):
         self.invoke('agents list --node-id a,b --node-id c')
@@ -60,4 +67,16 @@ class OptionsTest(CliCommandTest):
             install_methods=[],
             node_ids=['a', 'b', 'c'],
             node_instance_ids=[],
-            _all_tenants=False)
+            _all_tenants=False,
+            state=[AgentState.STARTED],
+        )
+
+    def test_agents_filters_all_states(self):
+        self.invoke('agents list --all-states')
+        self.client.agents.list.assert_called_with(
+            deployment_id=[],
+            install_methods=[],
+            node_ids=[],
+            node_instance_ids=[],
+            _all_tenants=False,
+        )


### PR DESCRIPTION
By default, `cfy agents list` only shows started agents; with this, it still does that, but CLI-side rather than restclient-side; and now it's also possible to list agents in other states.

Additionally, also show that state.