### PR TITLE
RND-363 Add --legacy parameter for snapshot create

### DIFF
--- a/cloudify_cli/cli/cfy.py
+++ b/cloudify_cli/cli/cfy.py
@@ -1431,6 +1431,13 @@ class Options(object):
             help=helptexts.TEMPDIR_PATH
         )
 
+        self.legacy = click.option(
+            '--legacy',
+            is_flag=True,
+            default=True,
+            help=helptexts.LEGACY_SNAPSHOT
+        )
+
         self.wait_for_status = click.option(
             '-w',
             '--wait-for-status',

--- a/cloudify_cli/cli/helptexts.py
+++ b/cloudify_cli/cli/helptexts.py
@@ -600,6 +600,7 @@ DRIFT_ONLY = 'Run update without changing anything. This will still check ' \
              'drift and run update operations as necessary'
 TEMPDIR_PATH = "Temporary location to be used for snapshot creation. If not " \
                "specified, /tmp will be used."
+LEGACY_SNAPSHOT = "Create legacy version of the snapshot (as opposed to 'new')"
 WAIT_FOR_STATUS = "Whether to wait for snapshot status [default: False]."
 SUMMARY_HELP = """
     Retrieve summary of {type}, e.g. a count of each {example}.

--- a/cloudify_cli/commands/snapshots.py
+++ b/cloudify_cli/commands/snapshots.py
@@ -37,7 +37,6 @@ SNAPSHOT_STATUSES = {
 def snapshots():
     """Handle manager snapshots
     """
-    pass
 
 
 @snapshots.command(name='restore',
@@ -97,6 +96,7 @@ def restore(snapshot_id,
 @cfy.options.common_options
 @cfy.options.queue_snapshot
 @cfy.options.tempdir_path
+@cfy.options.legacy
 @cfy.options.wait_for_status
 @cfy.pass_client()
 @cfy.pass_logger
@@ -106,6 +106,7 @@ def create(snapshot_id,
            exclude_events,
            queue,
            tempdir_path,
+           legacy,
            wait_for_status,
            logger,
            client):
@@ -124,7 +125,8 @@ def create(snapshot_id,
                                         not exclude_logs,
                                         not exclude_events,
                                         queue,
-                                        tempdir_path=tempdir_path)
+                                        tempdir_path=tempdir_path,
+                                        legacy=legacy)
     started_log_msg = "Started workflow execution. The execution's id is" \
                       " {0}.".format(execution.id)
     queued_log_msg = '`queue` flag was passed, snapshot creation will start' \


### PR DESCRIPTION
It results in creating a legacy snapshot, i.e. based on a database dump

By default this parameter's value is set to `True` for Cloudify 7.0 and `False` for versions 7.1 and higher.

---

This is a slightly modified cherry-pick of https://github.com/cloudify-cosmo/cloudify-cli/pull/1474 (the default value for `legacy` parameter is set to `True`).