### PR TITLE
RND-681 windows build: update pip/wheel/setuptools

### DIFF
--- a/packaging/windows/win_cli_builder.ps1
+++ b/packaging/windows/win_cli_builder.ps1
@@ -36,7 +36,6 @@ function rm_rf {
 
 
 ### Main ###
-
 Write-Host "Deleting existing artifacts"
 rm_rf python.zip
 rm_rf get-pip.py
@@ -107,6 +106,9 @@ run $CLI_PATH\python.exe get-pip.py pip==$PIP_VERSION
 
 Write-Host "Installing CLI"
 pushd cloudify-cli
+    run $CLI_PATH\python.exe -m pip install --upgrade pip
+    run $CLI_PATH\scripts\pip.exe install --upgrade wheel
+    run $CLI_PATH\scripts\pip.exe install --upgrade setuptools
     run $CLI_PATH\scripts\pip.exe install --prefix="$CLI_PATH" -r requirements.txt
     run $CLI_PATH\scripts\pip.exe install --prefix="$CLI_PATH" .
 popd


### PR DESCRIPTION
Upgrade all the build tools so that things like cryptography can be installed via wheel